### PR TITLE
add tests for invalid leaders and clean up leader spec

### DIFF
--- a/lib/marc_cleanup/bib_rubymarc_fixes.rb
+++ b/lib/marc_cleanup/bib_rubymarc_fixes.rb
@@ -6,25 +6,25 @@ module MarcCleanup
   #     normalize the indicator length and subfield code length to 2;
   #     make the last 4 positions the only possible value of '4500'
   def leaderfix(record)
-    correct_leader = /[0-9]{5}[acdnp][ac-gijkmoprt][a-dims][\sa][\sa]22[0-9]{5}[1-8uzI-M\s][aciu\s][abcr\s]4500/
+    correct_leader = /[0-9]{5}[acdnp][ac-gijkmoprt][a-dims][a\s]{2}22[0-9]{5}[1-578uzIJM\s][acinu\s][abc\s]4500/
     leader = record.leader
     return record if leader =~ correct_leader
-    length = leader[0, 5]
+    length = leader[0..4]
     status = leader[5]
-    status.gsub!(/[^acdnp]/, 'n')
+    status.gsub!(/[^acdnp]/, 'n') # Assume it is a new record
     record_type = leader[6]
     bib_level = leader[7]
     control = leader[8]
-    control.gsub!(/[^a ]/, ' ')
-    character_scheme = leader[9]
+    control.gsub!(/[^a\s]/, ' ') # Assume it is not an archival description
+    character_scheme = leader[9] # Not assuming it's Unicode or MARC-8
     indsub = '22'
-    base_addr = leader[12, 5]
+    base_addr = leader[12..16]
     enc_level = leader[17]
-    enc_level.gsub!(/[^1-8uzIJKLM ]/, 'u')
+    enc_level.gsub!(/[^1-578uzIJM\s]/, 'u') # If not valid, level is unknown
     cat_form = leader[18]
-    cat_form.gsub!(/[^aciu\s]/, 'u')
+    cat_form.gsub!(/[^acinu\s]/, 'u') # If not valid, cataloging form is unknown
     multipart = leader[19]
-    multipart.gsub!(/[^abcr ]/, ' ')
+    multipart.gsub!(/[^abc\s]/, ' ') # Assume it is not a multipart resource
     final4 = '4500'
     fixed_leader = [length, status, record_type, bib_level, control, character_scheme, indsub, base_addr, enc_level, cat_form, multipart, final4].join
     record.leader = fixed_leader

--- a/spec/fixtures/malformed_leaders/marc_with_invalid_leader.xml
+++ b/spec/fixtures/malformed_leaders/marc_with_invalid_leader.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0'?>
+<collection xmlns='http://www.loc.gov/MARC21/slim'
+      xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+      xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+<record>
+  <leader>01208bam a2200289 i 4500</leader>
+  <controlfield tag='001'>99127156556406421</controlfield>
+  <controlfield tag='005'>20230516151513.0</controlfield>
+  <controlfield tag='008'>230516m19821983nju      at   000 0 eng d</controlfield>
+  <datafield ind1=' ' ind2=' ' tag='040'>
+    <subfield code='a'>PUL</subfield>
+    <subfield code='b'>eng</subfield>
+    <subfield code='e'>rda</subfield>
+    <subfield code='c'>PUL</subfield>
+  </datafield>
+  <datafield ind1='0' ind2='0' tag='245'>
+    <subfield code='a'>[Princeton University Plasma Physics Laboratory reports]</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/leaderfix/leaderfix_spec.rb
+++ b/spec/leaderfix/leaderfix_spec.rb
@@ -1,13 +1,27 @@
-require "nokogiri"
-require "marc"
-require "byebug"
-require "marc_cleanup"
+require 'nokogiri'
+require 'marc'
+require 'byebug'
+require 'marc_cleanup'
 
-RSpec.describe 'test malformed leaders' do
-  let(:marcfile) {"#{Dir.getwd}/spec/fixtures/malformed_leaders/marc_with_valid_leader.xml"}
-    it 'knows that a record with a valid leader is valid' do  
-      reader = MARC::XMLReader.new(marcfile, parser: "magic", ignore_namespace: true)
-      record_with_valid_leader = reader.first
+RSpec.describe 'test leaders' do
+  describe 'valid leader' do
+    let(:marcfile) {"#{Dir.getwd}/spec/fixtures/malformed_leaders/marc_with_valid_leader.xml"}
+    let(:reader) { MARC::XMLReader.new(marcfile, parser: 'magic', ignore_namespace: true) }
+    let(:record_with_valid_leader) { reader.first }
+    it 'knows that a record with a valid leader is valid' do
       expect(MarcCleanup.leader_errors?(record_with_valid_leader)).to eq false
     end
   end
+  describe 'invalid leader' do
+    let(:marcfile) { "#{Dir.getwd}/spec/fixtures/malformed_leaders/marc_with_invalid_leader.xml" }
+    let(:reader) { MARC::XMLReader.new(marcfile, parser: 'magic') }
+    let(:record_with_invalid_leader) { reader.first }
+    it 'knows that a record with an invalid leader is invalid' do
+      expect(MarcCleanup.leader_errors?(record_with_invalid_leader)).to eq true
+    end
+    it 'corrects leader invalid position 5' do
+      corrected_record = MarcCleanup.leaderfix(record_with_invalid_leader)
+      expect(corrected_record.leader[5]).to eq 'n'
+    end
+  end
+end


### PR DESCRIPTION
Closes #42.
The MARC standard for the leader has changed slightly since the code was last updated.
To accommodate tests for invalid leaders, I also reformatted the leaderfix_spec tests.