### PR TITLE
test demonstrating that after leaderfix is executed on fixture record position 8 has become a space character

### DIFF
--- a/spec/fixtures/malformed_leaders/marc_with_invalid_leader.xml
+++ b/spec/fixtures/malformed_leaders/marc_with_invalid_leader.xml
@@ -3,7 +3,7 @@
       xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
       xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
 <record>
-  <leader>01208bam a2200289 i 4500</leader>
+  <leader>01208bamxa2200289 i 4500</leader>
   <controlfield tag='001'>99127156556406421</controlfield>
   <controlfield tag='005'>20230516151513.0</controlfield>
   <controlfield tag='008'>230516m19821983nju      at   000 0 eng d</controlfield>

--- a/spec/leaderfix/leaderfix_spec.rb
+++ b/spec/leaderfix/leaderfix_spec.rb
@@ -23,5 +23,9 @@ RSpec.describe 'test leaders' do
       corrected_record = MarcCleanup.leaderfix(record_with_invalid_leader)
       expect(corrected_record.leader[5]).to eq 'n'
     end
+    it 'corrects leader invalid position 8' do
+      corrected_record = MarcCleanup.leaderfix(record_with_invalid_leader)
+      expect(corrected_record.leader[8]).to eq ' '
+    end
   end
 end


### PR DESCRIPTION
Acceptance criteria:

- [x] Modify marc_with_invalid_leader.xml fixture object to have an invalid value in position 8 of the leader
- [x] Write a test demonstrating that after leaderfix is executed on this fixture record, position 8 has become a space character