### PR TITLE
Methods and test for 020 and ISBN clean up.

### DIFF
--- a/lib/marc_cleanup/constants.rb
+++ b/lib/marc_cleanup/constants.rb
@@ -6,5 +6,5 @@ module MarcCleanup
   END_OF_FIELD = 0x1E.chr
   END_OF_RECORD = 0x1D.chr
   ROOT_DIR = File.join(File.dirname(__FILE__), '../..')
-  ISBN13PREFIX = '978'
+  ISBN13PREFIX = '978'.freeze
 end

--- a/lib/marc_cleanup/constants.rb
+++ b/lib/marc_cleanup/constants.rb
@@ -6,4 +6,5 @@ module MarcCleanup
   END_OF_FIELD = 0x1E.chr
   END_OF_RECORD = 0x1D.chr
   ROOT_DIR = File.join(File.dirname(__FILE__), '../..')
+  ISBN13PREFIX = '978'
 end

--- a/lib/marc_cleanup/variable_fields.rb
+++ b/lib/marc_cleanup/variable_fields.rb
@@ -5,7 +5,7 @@ def new_020_q(record)
   record.fields('020').each do |f020|
     f020.subfields.each do |subfield|
       next unless subfield.code == 'a'
-      isbn_parts = /^\s*([^\s]+)\s+(\(.*?\))\s*$/.match(subfield.value)
+      isbn_parts = /^\s*([\d]+)\s*(\(.*?\))\s*$/.match(subfield.value)
       next if isbn_parts.nil?
       subfield.value = isbn_parts[1]
       f020.append(MARC::Subfield.new('q', isbn_parts[2])) 

--- a/lib/marc_cleanup/variable_fields.rb
+++ b/lib/marc_cleanup/variable_fields.rb
@@ -1,5 +1,122 @@
 module MarcCleanup
 
+### Remove non-numberical strings and append a new 020$q with the string
+def new_020_q(record)
+  record.fields('020').each do |f020|
+    f020.subfields.each do |subfield|
+      next unless subfield.code == 'a'
+      isbn_parts = /^\s*([^\s]+)\s+(\(.*?\))\s*$/.match(subfield.value)
+      next if isbn_parts.nil?
+      subfield.value = isbn_parts[1]
+      f020.append(MARC::Subfield.new('q', isbn_parts[2])) 
+    end  
+  end
+  record
+end
+
+### Convert ISBN-10 to ISBN-13
+def isbn10_to_13(isbn)
+  stem = isbn[0..8]
+  return nil if stem =~ /\D/
+
+  existing_check = isbn[9]
+  return nil if existing_check && existing_check != checkdigit_10(stem)
+
+  main = ISBN13PREFIX + stem
+  checkdigit = checkdigit_13(main)
+  main + checkdigit
+end
+
+### Calculate check digit for ISBN-10
+def checkdigit_10(stem)
+  int_index = 0
+  int_sum = 0
+  stem.each_char do |digit|
+    int_sum += digit.to_i * (10 - int_index)
+    int_index += 1
+  end
+  mod = (11 - (int_sum % 11)) % 11
+  mod == 10 ? 'X' : mod.to_s
+end
+
+### Calculate check digit for ISBN-13
+def checkdigit_13(stem)
+  int_index = 0
+  int_sum = 0
+  stem.each_char do |digit|
+    int_sum += int_index.even? ? digit.to_i : digit.to_i * 3
+    int_index += 1
+  end
+  ((10 - (int_sum % 10)) % 10).to_s
+end
+
+### Normalize ISBN-13
+def isbn13_normalize(raw_isbn)
+  int_sum = 0
+  stem = raw_isbn[0..11]
+  return nil if stem =~ /\D/
+
+  int_index = 0
+  stem.each_char do |digit|
+    int_sum += int_index.even? ? digit.to_i : digit.to_i * 3
+    int_index += 1
+  end
+  checkdigit = checkdigit_13(stem)
+  return nil if raw_isbn[12] && raw_isbn[12] != checkdigit
+
+  stem + checkdigit
+end
+
+### Normalize any given string that is supposed to include an ISBN
+def isbn_normalize(isbn)
+  return nil unless isbn
+
+  raw_isbn = isbn.dup
+  raw_isbn.delete!('-')
+  raw_isbn.delete!('\\')
+  raw_isbn.gsub!(/\([^\)]*\)/, '')
+  raw_isbn.gsub!(/^(.*)\$c.*$/, '\1')
+  raw_isbn.gsub!(/^(.*)\$q.*$/, '\1')
+  raw_isbn.gsub!(/^\D+([0-9].*)$/, '\1')
+  if raw_isbn =~ /^978/
+    raw_isbn.gsub!(/^(978[0-9 ]+).*$/, '\1')
+    raw_isbn.delete!(' ')
+  else
+    raw_isbn.gsub!(/([0-9])\s*([0-9]{4})\s*([0-9]{4})\s*([0-9xX]).*$/, '\1\2\3\4')
+  end
+  raw_isbn.gsub!(/^([0-9]{9,13}[xX]?)[^0-9xX].*$/, '\1')
+  raw_isbn.gsub!(/^([0-9]+?)\D.*$/, '\1')
+  if raw_isbn.length > 6 && raw_isbn.length < 9 && raw_isbn =~ /^[0-9]+$/
+    raw_isbn = raw_isbn.ljust(9, '0')
+  end
+  valid_lengths = [9, 10, 12, 13] # ISBN10 and ISBN13 with/out check digits
+  return nil unless valid_lengths.include? raw_isbn.length
+
+  if raw_isbn.length < 12
+    isbn10_to_13(raw_isbn)
+  else
+    isbn13_normalize(raw_isbn)
+  end
+end
+
+### If the ISBN is invalid, change the subfield code to z
+### Otherwise, replace ISBN with normalized ISBN
+def move_invalid_isbn(record)
+  record.fields('020').each do |f020|
+    f020.subfields.each do |subfield|
+      next unless subfield.code == 'a'
+      isbn = subfield.value
+      normalized_isbn = isbn_normalize(isbn)
+      if normalized_isbn
+        subfield.value = normalized_isbn
+      else
+        subfield.code = 'z'
+      end
+    end
+  end
+  record
+end
+
   # check the 041 field for errors
   # 041 is a language code
   def f041_errors?(record)

--- a/lib/marc_cleanup/variable_fields.rb
+++ b/lib/marc_cleanup/variable_fields.rb
@@ -1,11 +1,11 @@
 module MarcCleanup
 
-### Remove non-numberical strings and append a new 020$q with the string
+### Remove non-numerical strings and append a new 020$q with the string
 def new_020_q(record)
   record.fields('020').each do |f020|
     f020.subfields.each do |subfield|
       next unless subfield.code == 'a'
-      isbn_parts = /^\s*([\d]+)\s*(\(.*?\))\s*$/.match(subfield.value)
+      isbn_parts = /^\s*([\d\-]+)\s*(\(.*?\))\s*$/.match(subfield.value)
       next if isbn_parts.nil?
       subfield.value = isbn_parts[1]
       f020.append(MARC::Subfield.new('q', isbn_parts[2])) 

--- a/spec/variable_fields/020_spec.rb
+++ b/spec/variable_fields/020_spec.rb
@@ -5,31 +5,61 @@ require 'marc_cleanup'
 
 RSpec.describe 'field_020' do
   describe 'move_invalid_isbn' do
-    let(:fields) do
-      [
-        { '020' => { 'indicator1' => ' ',
-                     'indicator2' => ' ',
-                     'subfields' => [{ 'a' => '9780316458759' }] } },
-      ]
+    describe 'when isbn check digit is invalid' do
+      let(:fields) do
+        [
+          { '020' => { 'indicator1' => ' ',
+                       'indicator2' => ' ',
+                       'subfields' => [{ 'a' => '9780316458759' }] } },
+        ]
+      end
+      let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+      it 'moves an invalid isbn to the subfield z of an 020' do
+        move_invalid_isbn(record)
+        expect(record['020']['z']).to eq '9780316458759'
+      end
     end
-    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
-    it 'moves an invalid isbn to the subfield z of an 020' do
-      move_invalid_isbn(record)
-      expect(record['020']['z']).to eq '9780316458759'
+    describe 'when an isbn_10 is valid' do
+      let(:fields) do
+        [
+          { '020' => { 'indicator1' => ' ',
+                       'indicator2' => ' ',
+                       'subfields' => [{ 'a' => '0316458759' }] } },
+        ]
+      end
+      let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+      it 'converts isbn 10 to isbn 13 in subfield a of an 020' do
+        move_invalid_isbn(record)
+        expect(record['020']['a']).to eq '9780316458757'
+      end
     end
-  end
-  describe 'move_invalid_isbn' do
-    let(:fields) do
-      [
-        { '020' => { 'indicator1' => ' ',
-                     'indicator2' => ' ',
-                     'subfields' => [{ 'a' => '0316458759' }] } },
-      ]
+    describe 'when isbn 13 is valid' do
+      let(:fields) do
+        [
+          { '020' => { 'indicator1' => ' ',
+                       'indicator2' => ' ',
+                       'subfields' => [{ 'a' => '9780316458757' }] } },          
+        ]
+      end
+      let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+      it 'leaves the subfield a of an 020 the same' do
+        move_invalid_isbn(record)
+        expect(record['020']['a']).to eq '9780316458757'
+      end
     end
-    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
-    it 'moves an invalid isbn to the subfield z of an 020' do
-      move_invalid_isbn(record)
-      expect(record['020']['a']).to eq '9780316458757'
+    describe 'when an isbn is between 7 and 8 digits long' do
+      let(:fields) do
+        [
+          { '020' => { 'indicator1' => ' ',
+                       'indicator2' => ' ',
+                       'subfields' => [{ 'a' => '71543724' }] } },          
+        ]
+      end
+      let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+      it 'adds leading 0 and converts the isbn to an isbn 13 in subfield a of an 020' do
+        move_invalid_isbn(record)
+        expect(record['020']['a']).to eq '9787154372405'
+      end
     end
   end
   describe 'new_020_q' do

--- a/spec/variable_fields/020_spec.rb
+++ b/spec/variable_fields/020_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe 'field_020' do
       expect(record['020']['z']).to eq '9780316458759'
     end
   end
+  describe 'move_invalid_isbn' do
+    let(:fields) do
+      [
+        { '020' => { 'indicator1' => ' ',
+                     'indicator2' => ' ',
+                     'subfields' => [{ 'a' => '0316458759' }] } },
+      ]
+    end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+    it 'moves an invalid isbn to the subfield z of an 020' do
+      move_invalid_isbn(record)
+      expect(record['020']['a']).to eq '9780316458757'
+    end
+  end
 end

--- a/spec/variable_fields/020_spec.rb
+++ b/spec/variable_fields/020_spec.rb
@@ -1,0 +1,21 @@
+require 'nokogiri'
+require 'marc'
+require 'byebug'
+require 'marc_cleanup'
+
+RSpec.describe 'field_020' do
+  describe 'move_invalid_isbn' do
+    let(:fields) do
+      [
+        { '020' => { 'indicator1' => ' ',
+                     'indicator2' => ' ',
+                     'subfields' => [{ 'a' => '9780316458759' }] } },
+      ]
+    end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+    it 'moves an invalid isbn to the subfield z of an 020' do
+      move_invalid_isbn(record)
+      expect(record['020']['z']).to eq '9780316458759'
+    end
+  end
+end

--- a/spec/variable_fields/020_spec.rb
+++ b/spec/variable_fields/020_spec.rb
@@ -32,4 +32,19 @@ RSpec.describe 'field_020' do
       expect(record['020']['a']).to eq '9780316458757'
     end
   end
+  describe 'new_020_q' do
+    let(:fields) do
+      [
+        { '020' => { 'indicator1' => ' ',
+                     'indicator2' => ' ',
+                     'subfields' => [{ 'a' => '9780316458757(set)' }] } },
+      ]
+    end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+    it 'moves parathenticals to subfield q of an 020' do
+      new_020_q(record)
+      expect(record['020']['a']).to eq '9780316458757'
+      expect(record['020']['q']).to eq '(set)' 
+    end
+  end
 end


### PR DESCRIPTION
Methods to normalize ISBNs in field 020$a, move invalid ISBNs to 020$z, and move qualifying information from 020$a to 020$q.

Uses the following methods by Mark Zelesky <mzelesky@users.noreply.github.com>
`isbn10_to_13`
`checkdigit_10`
`checkdigit_13`
`isbn13_normalize`
`isbn_normalize`
