### PR TITLE
removed bad_008_length? method, updated 008_spec.rb

### DIFF
--- a/lib/marc_cleanup/fixed_fields.rb
+++ b/lib/marc_cleanup/fixed_fields.rb
@@ -1860,11 +1860,6 @@ module MarcCleanup
     false
   end
 
-  def bad_008_length?(record)
-    field = record['008'].value
-    field.length != 40
-  end
-
   def bad_008?(record)
     field = record['008'].value
     return true if field.length != 40

--- a/spec/fixed_fields/008_spec.rb
+++ b/spec/fixed_fields/008_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe 'field 008 methods' do
         expect(MarcCleanup.bad_008?(record)).to eq true
       end
     end
+      describe 'bad 008 length' do
+    let(:fields) do
+      [
+        { '008' => '230519s1996    njua         000 0 eng a' }
+      ]
+    end
+    let(:leader) { '01104naa a2200289 i 4500' }
+    let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
+    it 'knows a 008 length is wrong' do
+      expect(MarcCleanup.bad_008?(record)).to eq true
+    end
+  end
   end
   describe 'fix_008' do
     describe 'fix_book_008' do
@@ -187,17 +199,5 @@ RSpec.describe 'field 008 methods' do
         expect(fix_008(record)['008'].value).to eq '230519s1996    njua              0 eng d'     
       end
     end    
-  end
-  describe 'bad_008_length?' do
-    let(:fields) do
-      [
-        { '008' => '230519s1996    njua         000 0 eng a' }
-      ]
-    end
-    let(:leader) { '01104naa a2200289 i 4500' }
-    let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
-    it 'knows a 008 length is wrong' do
-      expect(bad_008_length?(record)).to eq true
-    end
   end
 end  


### PR DESCRIPTION
Removed the method `bad_008_length?` from fixed_fields.rb since the length test is included in the method `bad_008?`. Updated the 008_spec.rb to test the 008 length check using `bad_008?` instead of `bad_008_length?`.

Closes #76 