### PR TITLE
Updated fixture in `008_spec`

### DIFF
--- a/spec/fixed_fields/008_spec.rb
+++ b/spec/fixed_fields/008_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'field 008 methods' do
       let(:leader) { '01104nab a2200289 i 4500' }  
       
       context 'when the 008 is invalid' do    
-        let(:fields) { [ { '008' => '230519s1996    njua   u      000 0 eng d' } ] }
+        let(:fields) { [ { '008' => '230519s1996    njua   u aa   000 0 eng d' } ] }
         it { expect(MarcCleanup.bad_008?(record)).to eq true }
       end
       

--- a/spec/fixed_fields/008_spec.rb
+++ b/spec/fixed_fields/008_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'field 008 methods' do
       end
       
       context 'when the 008 is valid' do
-        let(:fields) { [ { '008' => '230519s1996    nju|| ||||||||0   ||eng d' } ] }        
+        let(:fields) { [ { '008' => '230519s1996    nju|| |||aa  |0   ||eng d' } ] }        
         it { expect(MarcCleanup.bad_008?(record)).to eq false }
       end
     end


### PR DESCRIPTION
Updated the invalid 008 fixture for the continuing resources format for the `bad_008?` method to cover the `cr_contents_codes` method as well.