### PR TITLE
Refactor empty_subfield_fix for memory usage

### DIFF
--- a/lib/marc_cleanup/variable_fields.rb
+++ b/lib/marc_cleanup/variable_fields.rb
@@ -510,28 +510,11 @@ end
 
   ### Remove empty subfields from DataFields
   def empty_subfield_fix(record)
-    fields_to_delete = []
-    curr_field = -1
     record.fields.each do |field|
-      curr_field += 1
       next unless field.class == MARC::DataField
-
-      curr_subfield = 0
-      subfields_to_delete = []
-      field.subfields.each do |subfield|
-        subfields_to_delete.unshift(curr_subfield) if subfield.value.empty? || subfield.value.nil?
-        curr_subfield += 1
-      end
-      subfields_to_delete.each do |i|
-        record.fields[curr_field].subfields.delete_at(i)
-      end
-      fields_to_delete.unshift(curr_field) if record.fields[curr_field].subfields.empty?
+      field.subfields.delete_if { |subfield| subfield.value.nil? || subfield.value.empty? }
     end
-    unless fields_to_delete.empty?
-      fields_to_delete.each do |i|
-        record.fields.delete_at(i)
-      end
-    end
+    record.fields.delete_if { |field| field.class == MARC::DataField && field.subfields.empty? }
     record
   end
 

--- a/spec/variable_fields/empty_subfield_spec.rb
+++ b/spec/variable_fields/empty_subfield_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'marc'
+require 'marc_cleanup'
+require 'byebug'
+
+RSpec.describe 'empty_subfield_fix method' do
+  describe 'when there are empty subfields' do
+    it 'removes them' do
+      original_hash = { 'fields' => [{
+        '020' => { 'indicator1' => ' ',
+                   'indicator2' => ' ',
+                   'subfields' => [{ 'a' => '9780316458759',
+                                     'b' => nil,
+                                     'c' => '',
+                                     'd' => nil,
+                                     'e' => '',
+                                     'z' => '' }] }
+      }, {
+        '035' => { 'indicator1' => ' ',
+                   'indicator2' => ' ',
+                   'subfields' => [{ 'a' => 'ocn123',
+                                     'b' => nil,
+                                     'c' => '4567' }] }
+      }] }
+      original = MARC::Record.new_from_hash(original_hash)
+
+      expected_hash = { 'fields' => [{
+        '020' => { 'indicator1' => ' ',
+                   'indicator2' => ' ',
+                   'subfields' => [{ 'a' => '9780316458759' }] }
+      }, {
+        '035' => { 'indicator1' => ' ',
+                   'indicator2' => ' ',
+                   'subfields' => [{ 'a' => 'ocn123',
+                                     'c' => '4567' }] }
+      }] }
+      expected = MARC::Record.new_from_hash(expected_hash)
+
+      fixed = MarcCleanup.empty_subfield_fix(original)
+      expect(fixed).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
This refactor saved 4 MB of memory while calling `empty_subfield_fix` on every MARC record in a 20 MB file.  To my eye, it is a bit more readable as well.

Here are the steps that I took to check the memory usage, in case they are useful:

```
bundle add memory_profiler
bundle console
require 'memory_profiler'
reader = MARC::XMLReader.new('/Users/sandbergj/Downloads/scsbfull_hl_20240101_230000_122.xml', parser: 'nokogiri')
report = MemoryProfiler.report do
  reader.each {|record| MarcCleanup.empty_subfield_fix(record) }
end
report.pretty_print
```