### PR TITLE
adds 880 linked field tag validation and local fields to schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.0
+      - image: cimg/ruby:3.2.0
     executor: ruby/default
     steps:
       - checkout
-      - run: gem install bundler -v '2.2.32'
+      - run: gem install bundler -v '2.5.22'
       - ruby/bundle-install
       - run:
           name: rspec

--- a/lib/marc_cleanup/record_level.rb
+++ b/lib/marc_cleanup/record_level.rb
@@ -1078,8 +1078,15 @@ module MarcCleanup
           hash[:invalid_fields][field.tag] << error
         else
           tag = field['6'].gsub(/^([0-9]{3})-.*$/, '\1')
+          unless schema[tag]
+            error = "Invalid linked field tag #{tag} in instance #{field_num} of 880"
+            hash[:invalid_fields][field.tag] ||= []
+            hash[:invalid_fields][field.tag] << error
+          end
         end
       end
+      next unless schema[tag]
+
       unless schema[tag]['ind1'].include?(field.indicator1.to_s)
         error = "Invalid indicator1 value #{field.indicator1.to_s} in instance #{field_num}"
         hash[:invalid_fields][field.tag] ||= []
@@ -1118,7 +1125,7 @@ module MarcCleanup
     if rda_convention_mismatch(record) == true
       record.leader[18] = "i"
     end
-    record 
+    record
   end
 
 end

--- a/marc_cleanup.gemspec
+++ b/marc_cleanup.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'marc', '~> 1.0'
   spec.add_dependency "nokogiri"
+  spec.add_dependency 'unf', '0.1.4'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency "byebug"
 end

--- a/spec/record_level/validate_marc_spec.rb
+++ b/spec/record_level/validate_marc_spec.rb
@@ -190,4 +190,20 @@ RSpec.describe 'validate_marc' do
       expect(record_errors[:invalid_fields]['880']).to include error_message
     end
   end
+  describe '880 field with valid linkage and with invalid linked tag' do
+    let(:fields) do
+      [
+        { '880' => { 'ind1' => ' ',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'Invalid linked field tag' },
+                                     { '6' => '591-00' }] } }
+      ]
+    end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+    it 'identifies the invalid linked field tag' do
+      record_errors = MarcCleanup.validate_marc(record: record)
+      error_message = 'Invalid linked field tag 591 in instance 1 of 880'
+      expect(record_errors[:invalid_fields]['880']).to include error_message
+    end
+  end
 end

--- a/yaml/field_schema.yml
+++ b/yaml/field_schema.yml
@@ -1362,7 +1362,7 @@
       repeat: true
       description: Classification number
     'b':
-      repeat: true
+      repeat: false
       description: Local Cutter number
     'e':
       repeat: false

--- a/yaml/field_schema.yml
+++ b/yaml/field_schema.yml
@@ -1352,6 +1352,25 @@
       repeat: true
       description: Field link and sequence number
 
+'090':
+  repeat: true
+  description: LOCALLY ASSIGNED LC-TYPE CALL NUMBER (OCLC)
+  ind1: [" "]
+  ind2: [" "]
+  subfields:
+    'a':
+      repeat: true
+      description: Classification number
+    'b':
+      repeat: true
+      description: Local Cutter number
+    'e':
+      repeat: false
+      description: Feature heading
+    'f':
+      repeat: false
+      description: Filing suffix
+
 '092':
   repeat: true
   description: LOCALLY ASSIGNED DEWEY CALL NUMBER (OCLC)
@@ -5111,6 +5130,25 @@
     '5':
       repeat: false
       description: Institution to which field applies
+    '6':
+      repeat: false
+      description: Linkage
+    '8':
+      repeat: true
+      description: Field link and sequence number
+
+'590':
+  repeat: true
+  description: LOCAL NOTE (OCLC)
+  ind1: [" ", "0", "1"]
+  ind2: [" "]
+  subfields:
+    'a':
+      repeat: false
+      description: Local note
+    '3':
+      repeat: false
+      description: Materials specified
     '6':
       repeat: false
       description: Linkage


### PR DESCRIPTION
Adds one additional validation for 880s where the linked tag is not a valid tag.
Removes an extra space from the end of a line in `rda_convention_correction`.

Adds 090 and 590 fields that are valid in the OCLC MARC schema.