### PR TITLE
add testing for subfield_sort and address all rubocop

### DIFF
--- a/spec/variable_fields/subfield_sort_spec.rb
+++ b/spec/variable_fields/subfield_sort_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'marc_cleanup'
+
+RSpec.describe 'subfield_sort' do
+  let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
+  let(:leader) { '01104naa a2200289 i 4500' }
+
+  context 'ControlField is provided as a target tag' do
+    let(:fields) do
+      [
+        { '009' => 'abc123' }
+      ]
+    end
+    let(:target_tags) { %w[009] }
+    it 'makes no change' do
+      changed_record = MarcCleanup.subfield_sort(record: record,
+                                                 target_tags: target_tags)
+      expect(changed_record['009'].value).to eq 'abc123'
+    end
+  end
+  context 'DataField is provided as a target tag with no order_array' do
+    let(:fields) do
+      [
+        { '500' => { 'ind1' => ' ',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'b' => 'Subfield b 1' },
+                                     { 'a' => 'Subfield a' },
+                                     { 'b' => 'Subfield b 2' }] } }
+      ]
+    end
+    let(:target_tags) { %w[500] }
+    it 'sorts by subfield code but keeps original order per subfield code' do
+      changed_record = MarcCleanup.subfield_sort(record: record,
+                                                 target_tags: target_tags)
+      expect(changed_record['500'].subfields[0].code).to eq 'a'
+      expect(changed_record['500'].subfields[0].value).to eq 'Subfield a'
+      expect(changed_record['500'].subfields[1].code).to eq 'b'
+      expect(changed_record['500'].subfields[1].value).to eq 'Subfield b 1'
+      expect(changed_record['500'].subfields[2].code).to eq 'b'
+      expect(changed_record['500'].subfields[2].value).to eq 'Subfield b 2'
+    end
+  end
+
+  context 'DataField is provided as a target tag with a partial order array' do
+    let(:fields) do
+      [
+        { '500' => { 'ind1' => ' ',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'b' => 'Subfield b 1' },
+                                     { 'c' => 'Subfield c' },
+                                     { 'a' => 'Subfield a' },
+                                     { 'b' => 'Subfield b 2' }] } }
+      ]
+    end
+    let(:target_tags) { %w[500] }
+    let(:order_array) { %w[a b] }
+    it 'sorts subfields in array and puts remaining subfields at the end' do
+      changed_record = MarcCleanup.subfield_sort(record: record,
+                                                 target_tags: target_tags)
+      expect(changed_record['500'].subfields[0].code).to eq 'a'
+      expect(changed_record['500'].subfields[0].value).to eq 'Subfield a'
+      expect(changed_record['500'].subfields[1].code).to eq 'b'
+      expect(changed_record['500'].subfields[1].value).to eq 'Subfield b 1'
+      expect(changed_record['500'].subfields[2].code).to eq 'b'
+      expect(changed_record['500'].subfields[2].value).to eq 'Subfield b 2'
+      expect(changed_record['500'].subfields[3].code).to eq 'c'
+      expect(changed_record['500'].subfields[3].value).to eq 'Subfield c'
+    end
+  end
+end


### PR DESCRIPTION
This was an exercise in applying the concepts learned in the Principles of Object Oriented Programming course.

The most important thing I took away from this week is the necessity of following a style guide. Library IT has been using rubocop as a style guide, which encapsulates https://rubystyle.guide/.

I am committing to addressing all rubocop issues before committing new code.

Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>