### PR TITLE
refactor relator_comma? and heading_end_punct?

### DIFF
--- a/lib/marc_cleanup/variable_fields.rb
+++ b/lib/marc_cleanup/variable_fields.rb
@@ -354,38 +354,52 @@ module MarcCleanup
   end
 
   def relator_comma?(record)
-    comma_regex = /^.*[^,]$/
-    record.fields.each do |field|
-      next unless field.tag =~ /[17][01][01]/
-
-      code_array = ''
-      field.subfields.each do |subfield|
-        code_array << subfield.code
-      end
-      if field.tag =~ /[17][01]0/
-        subfx_e_index = code_array.index(/.e/)
-        return true if subfx_e_index && field.subfields[subfx_e_index].value =~ comma_regex
-      elsif field.tag =~ /[17]11/
-        subfx_j_index = code_array.index(/.j/)
-        return true if subfx_j_index && field.subfields[subfx_j_index].value =~ comma_regex
-      end
+    record.fields(%w[100 110 111 700 710 711]).each do |field|
+      relator_index = relator_subfield_index(field)
+      next unless relator_index
+      return true if field.subfields[relator_index - 1].value =~ /[^,]$/
     end
     false
   end
 
-  def heading_end_punct?(record)
-    punct_regex = /.*[^"\).\!\?\-]$/
-    record.fields.each do |field|
-      next unless field.tag =~ /^[167][0-5].$/ && field.indicator2 =~ /[^47]/
+  def relator_subfield_index(field)
+    case field.tag
+    when '111', '711'
+      field.subfields.index { |subfield| subfield.code == 'j' }
+    else
+      field.subfields.index { |subfield| subfield.code == 'e' }
+    end
+  end
 
-      code_array = ''
-      field.subfields.each do |subfield|
-        code_array << subfield.code
-      end
-      last_heading_subfield_index = code_array.index(/[a-vx-z8][^a-vx-z8]*$/)
-      return true if last_heading_subfield_index && field.subfields[last_heading_subfield_index].value =~ punct_regex
+  def heading_end_punct?(record)
+    punct_regex = /[^").!?-]$/
+    record.fields(punctuated_heading_fields).each do |field|
+      last_heading_subfield = last_heading_subfield(field)
+      next unless last_heading_subfield
+      return true if last_heading_subfield.value =~ punct_regex
     end
     false
+  end
+
+  def punctuated_heading_fields
+    %w[
+      100 110 111 130
+      600 610 611 630 650 651 654 655 656 657 658 662
+      700 710 711 730 740 752 754
+      800 810 811 830
+    ]
+  end
+
+  def last_heading_subfield(field)
+    regex = /[^02345]/
+    heading_subfields = field.subfields.select do |subfield|
+      subfield.code =~ regex
+    end
+    if heading_subfields.empty?
+      nil
+    else
+      heading_subfields[-1]
+    end
   end
 
   def subf_0_uri?(record)

--- a/spec/variable_fields/heading_punctuation_spec.rb
+++ b/spec/variable_fields/heading_punctuation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'x00_subfq?' do
   let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
   let(:leader) { '01104naa a2200289 i 4500' }
 
-  context '100 field has subfield q with no parentheses' do
+  context '100 field subfield q with no parentheses' do
     let(:fields) do
       [
         { '100' => { 'ind1' => '0',
@@ -89,7 +89,7 @@ RSpec.describe 'x00_subfq?' do
     end
   end
 
-  context '100 field has subfield q with parentheses' do
+  context '100 field subfield q with parentheses' do
     let(:fields) do
       [
         { '100' => { 'ind1' => '0',
@@ -98,7 +98,7 @@ RSpec.describe 'x00_subfq?' do
                                      { 'q' => '(Xavier)' }] } }
       ]
     end
-    it 'does not returns an error' do
+    it 'does not return an error' do
       expect(MarcCleanup.x00_subfq?(record)).to be false
     end
   end

--- a/spec/variable_fields/heading_punctuation_spec.rb
+++ b/spec/variable_fields/heading_punctuation_spec.rb
@@ -137,3 +137,107 @@ RSpec.describe 'x00_subfd_no_comma?' do
     end
   end
 end
+
+RSpec.describe 'relator_comma?' do
+  let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
+  let(:leader) { '01104naa a2200289 i 4500' }
+
+  context '700 field has a comma before the first relator term' do
+    let(:fields) do
+      [
+        { '700' => { 'ind1' => '0',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X,' },
+                                     { 'e' => 'editor,' },
+                                     { 'e' => 'author of afterword, colophon, etc.' },
+                                     { 'e' => 'plaintiff-appellant.' }] } }
+      ]
+    end
+    it 'does not return an error' do
+      expect(MarcCleanup.relator_comma?(record)).to be false
+    end
+  end
+
+  context '700 field is missing a comma before the first relator term' do
+    let(:fields) do
+      [
+        { '700' => { 'ind1' => '0',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X?' },
+                                     { 'e' => 'Editor,' },
+                                     { 'e' => 'author of afterword, colophon, etc.' },
+                                     { 'e' => 'plaintiff-appellant' }] } }
+      ]
+    end
+    it 'returns an error' do
+      expect(MarcCleanup.relator_comma?(record)).to be true
+    end
+  end
+
+  context '711 field has a comma before the first relator term' do
+    let(:fields) do
+      [
+        { '711' => { 'ind1' => '2',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X Symposium,' },
+                                     { 'j' => 'editor,' },
+                                     { 'j' => 'author of afterword, colophon, etc.' },
+                                     { 'j' => 'plaintiff-appellant.' }] } }
+      ]
+    end
+    it 'does not return an error' do
+      expect(MarcCleanup.relator_comma?(record)).to be false
+    end
+  end
+
+  context '711 field is missing a comma before the first relator term' do
+    let(:fields) do
+      [
+        { '711' => { 'ind1' => '2',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X Symposium!' },
+                                     { 'j' => 'editor,' },
+                                     { 'j' => 'author of afterword, colophon, etc.' },
+                                     { 'j' => 'plaintiff-appellant?' }] } }
+      ]
+    end
+    it 'returns an error' do
+      expect(MarcCleanup.relator_comma?(record)).to be true
+    end
+  end
+end
+
+RSpec.describe 'heading_end_punct?' do
+  let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
+  let(:leader) { '01104naa a2200289 i 4500' }
+
+  context '700 field has proper end punctuation' do
+    let(:fields) do
+      [
+        { '700' => { 'ind1' => '0',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X,' },
+                                     { 'd' => '1961-' },
+                                     { '4' => 'edt' }] } }
+      ]
+    end
+    it 'does not return an error' do
+      expect(MarcCleanup.heading_end_punct?(record)).to be false
+    end
+  end
+
+  context '700 field does not have proper end punctuation' do
+    let(:fields) do
+      [
+        { '700' => { 'ind1' => '0',
+                     'ind2' => ' ',
+                     'subfields' => [{ 'a' => 'X?' },
+                                     { 'e' => 'editor' },
+                                     { '4' => 'edt' }] } }
+      ]
+    end
+    it 'returns an error' do
+      expect(MarcCleanup.heading_end_punct?(record)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Closes #157.

The method `heading_end_punct?` didn't follow the guidelines provided at https://loc.gov/marc/bibliographic/bdheading.html and the MARC definitions of 6XX fields. I gathered all heading fields that should have punctuation according to the MARC format.