### PR TITLE
add case_sensitive param to replace_field(s)

### DIFF
--- a/spec/record_level/replace_field_spec.rb
+++ b/spec/record_level/replace_field_spec.rb
@@ -64,4 +64,18 @@ RSpec.describe 'replace_field' do
       expect(record['020']['z']).to be_nil
     end
   end
+  context 'source/target case-insensitive match' do
+    let(:fields) { [{ '009' => 'LoC' }] }
+    let(:source_field) { MARC::ControlField.new('009', 'loc') }
+    let(:replacement_field) { MARC::ControlField.new('009', 'OCLC') }
+    it 'does not replace content when case-sensitive is true' do
+      replace_field(source_field: source_field, replacement_field: replacement_field, record: record)
+      expect(record['009'].value).to eq 'LoC'
+    end
+    it 'replaces content when case-insensitive is false' do
+      replace_field(source_field: source_field, replacement_field: replacement_field, record: record,
+                    case_sensitive: false)
+      expect(record['009'].value).to eq 'OCLC'
+    end
+  end
 end

--- a/spec/record_level/replace_fields_spec.rb
+++ b/spec/record_level/replace_fields_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'replace_fields' do
           case_sensitive: case_sensitive_b }
       ]
     end
-    it 'changes field only where ignore_indicators is set to true' do
+    it 'changes field only where case_sensitive is set to true' do
       replace_fields(field_array: field_array, record: record)
       expect(record['901']['a']).to eq 'loc'
       expect(record['902']).to be_nil

--- a/spec/record_level/replace_fields_spec.rb
+++ b/spec/record_level/replace_fields_spec.rb
@@ -42,4 +42,35 @@ RSpec.describe 'replace_fields' do
       expect(record['904'].indicator2).to eq '1'
     end
   end
+  context 'all field pairings match in a case-insensitive way' do
+    let(:fields) do
+      [
+        { '901' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'a' => 'loc' }] } },
+        { '902' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'a' => 'OCLC' }] } }
+      ]
+    end
+    let(:source_field_a) { MARC::DataField.new('901', '0', '0', MARC::Subfield.new('a', 'LoC')) }
+    let(:replacement_field_a) { MARC::DataField.new('903', '0', '0', MARC::Subfield.new('a', 'LC')) }
+
+    let(:source_field_b) { MARC::DataField.new('902', '0', '0', MARC::Subfield.new('a', 'oclc')) }
+    let(:replacement_field_b) { MARC::DataField.new('904', '0', '0', MARC::Subfield.new('a', 'OCoLC')) }
+    let(:case_sensitive_b) { false }
+
+    let(:field_array) do
+      [
+        { source_field: source_field_a,
+          replacement_field: replacement_field_a },
+        { source_field: source_field_b,
+          replacement_field: replacement_field_b,
+          case_sensitive: case_sensitive_b }
+      ]
+    end
+    it 'changes field only where ignore_indicators is set to true' do
+      replace_fields(field_array: field_array, record: record)
+      expect(record['901']['a']).to eq 'loc'
+      expect(record['902']).to be_nil
+      expect(record['903']).to be_nil
+      expect(record['904']['a']).to eq 'OCoLC'
+    end
+  end
 end


### PR DESCRIPTION
This adds the parameter `case_senstive` to `replace_field`, and allows `replace_fields` to include such a param in its `field_array`.  Added tests to the respective rspec fields, which passed.  I discovered in the process of testing this that I had not done the null coalescing properly in the previous iteration of `replace_fields`.   This has been fixed. Also, rubocop outputs the following warnings about `replace_field`

```
lib/marc_cleanup/record_level.rb:302:3: C: Metrics/AbcSize: Assignment Branch Condition size for replace_field is too high. [<7, 15, 6> 17.61/17]
  def replace_field(source_field:, replacement_field:, record:, ignore_indicators: false, case_sensitive: true) ...
lib/marc_cleanup/record_level.rb:302:3: C: Metrics/MethodLength: Method has too many lines. [12/10]
  def replace_field(source_field:, replacement_field:, record:, ignore_indicators: false, case_sensitive: true) ...
 ```

I'm not sure if these can or should be addressed, but @mzelesky let me know what you think.