### PR TITLE
test, rename, and refactor field_delete

### DIFF
--- a/lib/marc_cleanup/record_level.rb
+++ b/lib/marc_cleanup/record_level.rb
@@ -273,27 +273,22 @@ module MarcCleanup
 
   ## Can delete fields based on tags alone, or with
   ## optional indicator values provided in arrays
-  def field_delete(tags, record, indicators = {})
-    if indicators.empty?
-      record.fields.delete_if { |field| tags.include? field.tag }
-    else
-      ind_1 = indicators[:ind_1]
-      ind_2 = indicators[:ind_2]
-      if ind_1 && ind_2
-        record.fields.delete_if { |field| (tags.include? field.tag) && (ind_1.include? field.indicator1) && (ind_2.include? field.indicator2) }
-      elsif ind_1
-        record.fields.delete_if { |field| (tags.include? field.tag) && (ind_1.include? field.indicator1) }
-      else
-        record.fields.delete_if { |field| (tags.include? field.tag) && (ind_2.include? field.indicator2) }
-      end
+  def field_delete_by_tags(record:, tags:, indicators: {})
+    full_indicator_array = [' ']
+    full_indicator_array += %w[0 1 2 3 4 5 6 7 8 9]
+    indicators[:ind1] ||= full_indicator_array
+    indicators[:ind2] ||= full_indicator_array
+    record.fields.delete_if do |field|
+      tags.include?(field.tag) &&
+        indicators[:ind1].include?(field.indicator1) &&
+        indicators[:ind2].include?(field.indicator2)
     end
     record
   end
 
   def recap_fixes(record)
     record = bad_utf8_scrub(record)
-    record = field_delete(['959'], record)
-    record = field_delete(['856'], record)
+    record = field_delete_by_tags(record: record, tags: %w[959 856])
     record = leaderfix(record)
     record = extra_space_fix(record)
     record = invalid_xml_fix(record)

--- a/spec/record_level/field_delete_by_tags_spec.rb
+++ b/spec/record_level/field_delete_by_tags_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'marc_cleanup'
+require 'byebug'
+
+RSpec.describe 'field_delete_by_tags' do
+  let(:record) { MARC::Record.new_from_hash('fields' => fields) }
+
+  context 'tags are provided with no indicators' do
+    let(:fields) do
+      [
+        { '901' => {
+          'ind1' => '0',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '901' }]
+        } },
+        { '902' => {
+          'ind1' => '1',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '902' }]
+        } },
+        { '020' => {
+          'ind1' => '2',
+          'ind2' => '1',
+          'subfields' => [{ 'a' => 'subfield' }]
+        } }
+      ]
+    end
+    let(:tags) { %w[901 902 020] }
+    it 'removes all fields' do
+      field_delete_by_tags(record: record, tags: tags)
+      expect(record['901']).to be_nil
+      expect(record['902']).to be_nil
+      expect(record['020']).to be_nil
+    end
+  end
+
+  context 'tags are provided with both indicators' do
+    let(:fields) do
+      [
+        { '901' => {
+          'ind1' => '0',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '901' }]
+        } },
+        { '902' => {
+          'ind1' => '1',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '902' }]
+        } },
+        { '020' => {
+          'ind1' => '2',
+          'ind2' => '1',
+          'subfields' => [{ 'a' => 'subfield' }]
+        } }
+      ]
+    end
+    let(:tags) { %w[901 902 020] }
+    let(:indicators) { { ind1: %w[0 1 2], ind2: %w[0] } }
+    it 'removes fields that match indicators' do
+      field_delete_by_tags(record: record, tags: tags, indicators: indicators)
+      expect(record['901']).to be_nil
+      expect(record['902']).to be_nil
+      expect(record['020']['a']).to eq 'subfield'
+    end
+  end
+
+  context 'tags are provided with indicator1' do
+    let(:fields) do
+      [
+        { '901' => {
+          'ind1' => '0',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '901' }]
+        } },
+        { '902' => {
+          'ind1' => '1',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '902' }]
+        } },
+        { '020' => {
+          'ind1' => '2',
+          'ind2' => '1',
+          'subfields' => [{ 'a' => 'subfield' }]
+        } }
+      ]
+    end
+    let(:tags) { %w[901 902 020] }
+    let(:indicators) { { ind1: %w[0 2] } }
+    it 'removes field that matches indicators' do
+      field_delete_by_tags(record: record, tags: tags, indicators: indicators)
+      expect(record['901']).to be_nil
+      expect(record['902']['a']).to eq '902'
+      expect(record['020']).to be_nil
+    end
+  end
+
+  context 'tags are provided with indicator2' do
+    let(:fields) do
+      [
+        { '901' => {
+          'ind1' => '0',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '901' }]
+        } },
+        { '902' => {
+          'ind1' => '1',
+          'ind2' => '0',
+          'subfields' => [{ 'a' => '902' }]
+        } },
+        { '020' => {
+          'ind1' => '2',
+          'ind2' => '1',
+          'subfields' => [{ 'a' => 'subfield' }]
+        } }
+      ]
+    end
+    let(:tags) { %w[901 902 020] }
+    let(:indicators) { { ind2: %w[0] } }
+    it 'removes fields that match indicators' do
+      field_delete_by_tags(record: record, tags: tags, indicators: indicators)
+      expect(record['901']).to be_nil
+      expect(record['902']).to be_nil
+      expect(record['020']['a']).to eq 'subfield'
+    end
+  end
+end


### PR DESCRIPTION
To distinguish `remove_fields` from `field_delete`, I renamed the method to `field_delete_by_tags`. This method is called by `recap_fixes`, which is used in bibdata, so I made sure to change the method name there.