### PR TITLE
refactor and test duplicate_record to allow for extra-large MARC

### DIFF
--- a/lib/marc_cleanup/record_level.rb
+++ b/lib/marc_cleanup/record_level.rb
@@ -472,16 +472,16 @@ module MarcCleanup
     record
   end
 
-  ### Duplicate record to preserve original when making modifications
+  ### Duplicate record to preserve original when making modifications;
+  ###   must scrub any invalid UTF-8 before duplicating
   def duplicate_record(record)
-    raw_marc = ''
-    writer = MARC::Writer.new(StringIO.new(raw_marc, 'w'))
+    raw_marc = ''.dup
+    writer = MARC::XMLWriter.new(StringIO.new(raw_marc, 'w'))
+    record = bad_utf8_scrub(record)
     writer.write(record)
     writer.close
-    reader = MARC::Reader.new(StringIO.new(raw_marc, 'r'),
-                              external_encoding: 'UTF-8',
-                              invalid: :replace,
-                              replace: '')
+    reader = MARC::XMLReader.new(StringIO.new(raw_marc, 'r'),
+                                 external_encoding: 'UTF-8')
     reader.first
   end
 

--- a/spec/record_level/duplicate_record_spec.rb
+++ b/spec/record_level/duplicate_record_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'marc_cleanup'
+
+RSpec.describe 'duplicate_record' do
+  let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
+
+  context 'existing field has invalid UTF-8' do
+    let(:fields) { [{ '009' => "Ma\x80\xc4rk" }] }
+    let(:leader) { '01104naa a2200289 i 4500' }
+    it 'creates new record with different object ID and scrubs invalid UTF-8' do
+      new_record = duplicate_record(record)
+      expect(new_record.object_id).not_to eq record.object_id
+      expect(new_record['009'].value).to eq 'Mark'
+      expect(new_record['009'.object_id]).not_to eq record['009'].object_id
+    end
+  end
+
+  context 'existing field has length that is longer than binary MARC allows' do
+    let(:fields) { [{ '009' => ('a' * 10_000) }] }
+    let(:leader) { '01104naa a2200289 i 4500' }
+    it 'creates new record with different object ID' do
+      new_record = duplicate_record(record)
+      expect(new_record.object_id).not_to eq record.object_id
+      expect(new_record['009'].value).to eq ('a' * 10_000)
+    end
+  end
+
+  context 'existing record has length that is longer than binary MARC allows' do
+    let(:fields) do
+      [
+        { '001' => ('a' * 9_000) },
+        { '002' => ('a' * 9_000) },
+        { '003' => ('a' * 9_000) },
+        { '004' => ('a' * 9_000) },
+        { '005' => ('a' * 9_000) },
+        { '006' => ('a' * 9_000) },
+        { '007' => ('a' * 9_000) },
+        { '008' => ('a' * 9_000) },
+        { '009' => ('a' * 9_000) },
+        { '009' => ('a' * 9_000) },
+        { '009' => ('a' * 9_000) }
+      ]
+    end
+    let(:leader) { '01104naa a2200289 i 4500' }
+    it 'creates new record with different object ID' do
+      new_record = duplicate_record(record)
+      expect(new_record.object_id).not_to eq record.object_id
+      expect(new_record['001'].value).to eq ('a' * 9_000)
+    end
+  end
+end


### PR DESCRIPTION
`MARC::Writer` can't handle records with a field length greater than 9,999 bytes or a record length greater than 99,999 bytes due to the MARC format limitation. `MARC::XMLWriter` does not have this limitation.