### PR TITLE
add frozen_string_literal to fixed_fields and rubocop autofixes on fixed fields

### DIFF
--- a/lib/marc_cleanup/fixed_fields.rb
+++ b/lib/marc_cleanup/fixed_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MarcCleanup
   def no_001?(record)
     record['001'].nil?
@@ -6,11 +8,11 @@ module MarcCleanup
   def fixed_field_char_errors?(record)
     fields = record.fields('001'..'009').map(&:value)
     bad_fields = fields.reject { |value| value.bytesize == value.chars.size }
-    bad_fields += fields.select { |value| value =~ /[^a-z0-9 |.A-Z\-]/ }
+    bad_fields += fields.select { |value| value =~ /[^a-z0-9 |.A-Z-]/ }
     !bad_fields.empty?
   end
 
-  def multiple_no_008?(record)
+  def multiple_no_f008?(record)
     record.fields('008').size != 1
   end
 
@@ -1142,7 +1144,7 @@ module MarcCleanup
     /^[a-dfgik-tvwz|]$/
   end
 
-  def all_008(field)
+  def all_f008(field)
     date_entered = field[0..5]
     date_type = field[6]
     date1 = field[7..10]
@@ -1157,19 +1159,19 @@ module MarcCleanup
 
     case date_type
     when 'e'
-      return true unless date2 =~ /^[0-9]+[ ]*$/
+      return true unless date2 =~ /^[0-9]+\s*$/
     else
       return true unless date2 == '||||' || date2 == '    ' || date2 =~ /^[0-9u]{4}$/
     end
     return true unless place == '|||' || place_codes.include?(place)
     return true unless lang == '|||'  || lang_codes.include?(lang)
-    return true unless %w[\  d o r s x |].include?(modified)
-    return true unless %w[\  c d u |].include?(cat_source)
+    return true unless [' ', 'd', 'o', 'r', 's', 'x', '|'].include?(modified)
+    return true unless [' ', 'c', 'd', 'u', '|'].include?(cat_source)
 
     false
   end
 
-  def book_008(field)
+  def book_f008(field)
     illus = field[0..3]
     audience = field[4]
     item_form = field[5]
@@ -1196,7 +1198,7 @@ module MarcCleanup
     false
   end
 
-  def comp_008(field)
+  def comp_f008(field)
     undef1 = field[0..3]
     audience = field[4]
     item_form = field[5]
@@ -1217,7 +1219,7 @@ module MarcCleanup
     false
   end
 
-  def map_008(field)
+  def map_f008(field)
     relief = field[0..3]
     proj = field[4..5]
     undef1 = field[6]
@@ -1244,7 +1246,7 @@ module MarcCleanup
     false
   end
 
-  def music_008(field)
+  def music_f008(field)
     comp_form = field[0..1]
     music_format = field[2]
     parts = field[3]
@@ -1269,7 +1271,7 @@ module MarcCleanup
     false
   end
 
-  def continuing_resource_008(field)
+  def continuing_resource_f008(field)
     freq = field[0]
     reg = field[1]
     undef1 = field[2]
@@ -1300,7 +1302,7 @@ module MarcCleanup
     false
   end
 
-  def visual_008(field)
+  def visual_f008(field)
     runtime = field[0..2]
     undef1 = field[3]
     audience = field[4]
@@ -1323,7 +1325,7 @@ module MarcCleanup
     false
   end
 
-  def mix_mat_008(field)
+  def mix_mat_f008(field)
     undef1 = field[0..4]
     item_form = field[5]
     undef2 = field[6..16]
@@ -1467,7 +1469,7 @@ module MarcCleanup
     ]
   end
 
-  def bad_005?(record)
+  def bad_f005?(record)
     field = record['005']
     return false unless field
 
@@ -1475,7 +1477,7 @@ module MarcCleanup
   end
 
   # Uses same methods as the specific 008 methods
-  def bad_006?(record)
+  def bad_f006?(record)
     fields = record.fields('006')
     return false if fields.empty?
 
@@ -1483,28 +1485,28 @@ module MarcCleanup
       return true if field.value.length != 18
 
       rec_type = field.value[0]
-      specific_006 = field.value[1..-1]
+      specific_f006 = field.value[1..]
       case rec_type
       when 'a', 't'
-        return true if book_008(specific_006)
+        return true if book_f008(specific_f006)
       when 'm'
-        return true if comp_008(specific_006)
+        return true if comp_f008(specific_f006)
       when 'e', 'f'
-        return true if map_008(specific_006)
+        return true if map_f008(specific_f006)
       when 'c', 'd', 'i', 'j'
-        return true if music_008(specific_006)
+        return true if music_f008(specific_f006)
       when 's'
-        return true if continuing_resource_008(specific_006)
+        return true if continuing_resource_f008(specific_f006)
       when 'g', 'k', 'o', 'r'
-        return true if visual_008(specific_006)
+        return true if visual_f008(specific_f006)
       when 'p'
-        return true if mix_mat_008(specific_006)
+        return true if mix_mat_f008(specific_f006)
       end
     end
     false
   end
 
-  def map_007(field)
+  def map_f007(field)
     return true unless field.length == 7
     return true unless %w[d g j k q r s u y z |].include?(field[0])
     return true unless field[1] == ' '
@@ -1517,13 +1519,13 @@ module MarcCleanup
     false
   end
 
-  def elec_007(field)
+  def elec_f007(field)
     return true unless field.length == 13
     return true unless %w[a b c d e f h j k m o r s u z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[a b c g m n u z |].include?(field[2])
     return true unless %w[a e g i j n o u v z |].include?(field[3])
-    return true unless %w[\  a u |].include?(field[4])
+    return true unless [' ', 'a', 'u', '|'].include?(field[4])
     return true unless %w[mmm nnn --- |||].include?(field[5..7]) || field[5..7] =~ /^[0-9]{3}$/
     return true unless %w[a m u |].include?(field[8])
     return true unless %w[a n p u |].include?(field[9])
@@ -1534,7 +1536,7 @@ module MarcCleanup
     false
   end
 
-  def globe_007(field)
+  def globe_f007(field)
     return true unless field.length == 5
     return true unless %w[a b c e u z |].include?(field[0])
     return true unless field[1] == ' '
@@ -1545,7 +1547,7 @@ module MarcCleanup
     false
   end
 
-  def tactile_007(field)
+  def tactile_f007(field)
     return true unless field.length == 9
     return true unless %w[a b c d u z |].include?(field[0])
     return true unless field[1] == ' '
@@ -1557,28 +1559,28 @@ module MarcCleanup
     false
   end
 
-  def proj_graphic_007(field)
+  def proj_graphic_f007(field)
     return true unless field.length == 8
     return true unless %w[c d f o s t u z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[a b c h m n u z |].include?(field[2])
     return true unless %w[d e j k m o u z |].include?(field[3])
-    return true unless %w[\  a b u |].include?(field[4])
-    return true unless %w[\  a b c d e f g h i u z |].include?(field[5])
+    return true unless [' ', 'a', 'b', 'u', '|'].include?(field[4])
+    return true unless [' ', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'u', 'z', '|'].include?(field[5])
     return true unless %w[a b c d e f g j k s t v w x y u z |].include?(field[6])
-    return true unless %w[\  c d e h j k m u z |].include?(field[7])
+    return true unless [' ', 'c', 'd', 'e', 'h', 'j', 'k', 'm', 'u', 'z', '|'].include?(field[7])
 
     false
   end
 
-  def microform_007(field)
+  def microform_f007(field)
     return true unless field.length == 12
     return true unless %w[a b c d e f g h j u z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[a b m u |].include?(field[2])
     return true unless %w[a d f g h l m o p u z |].include?(field[3])
     return true unless %w[a b c d e u v |].include?(field[4])
-    return true unless field[5..7] == '|||' || field[5..7] =~ /^[0-9]+[\-]*$/
+    return true unless field[5..7] == '|||' || field[5..7] =~ /^[0-9]+-*$/
     return true unless %w[b c m u z |].include?(field[8])
     return true unless %w[a b c m n u z |].include?(field[9])
     return true unless %w[a b c m u |].include?(field[10])
@@ -1587,25 +1589,26 @@ module MarcCleanup
     false
   end
 
-  def nonproj_graphic_007(field)
+  def nonproj_graphic_f007(field)
     return true unless field.length == 5
     return true unless %w[a c d e f g h i j k l n o p q r s u v z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[a b c h m u z |].include?(field[2])
     return true unless %w[a b c d e f g h i l m n o p q r s t u v w z |].include?(field[3])
-    return true unless %w[\  a b c d e f g h i l m n o p q r s t u v w z |].include?(field[4])
+    return true unless [' ', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+                        'u', 'v', 'w', 'z', '|'].include?(field[4])
 
     false
   end
 
-  def motion_pict_007(field)
+  def motion_pict_f007(field)
     return true unless field.length > 6
     return true unless %w[c f o r u z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[b c h m n u z |].include?(field[2])
     return true unless %w[a b c d e f u z |].include?(field[3])
-    return true unless %w[\  a b u |].include?(field[4])
-    return true unless %w[\  a b c d e f g h i u z |].include?(field[5])
+    return true unless [' ', 'a', 'b', 'u', '|'].include?(field[4])
+    return true unless [' ', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'u', 'z', '|'].include?(field[5])
     return true unless %w[a b c d e f g u z |].include?(field[6])
     return true unless field[7].nil? || field[7] =~ /[kmnqsuz|]/
     return true unless field[8].nil? || field[8] =~ /[a-gnz|]/
@@ -1621,15 +1624,15 @@ module MarcCleanup
     case inspect_date
     when '||||||', '------'
       false
-    when /^[0-9]+[\-]*$/
+    when /^[0-9]+-*$/
       false
     else
       true
     end
   end
 
-# Kit and notated music are tested with the same method
-  def kit_mus_007(field)
+  # Kit and notated music are tested with the same method
+  def kit_mus_f007(field)
     return true unless field.length == 1
 
     %w[u |].include?(field[0]) ? false : true
@@ -1682,7 +1685,7 @@ module MarcCleanup
     ]
   end
 
-  def remote_007(field)
+  def remote_f007(field)
     return true unless field.length == 10
     return true unless field[0] =~ /[u|]/
     return true unless field[1] == ' '
@@ -1697,7 +1700,7 @@ module MarcCleanup
     false
   end
 
-  def recording_007(field)
+  def recording_f007(field)
     return true unless field.length == 13
     return true unless %w[d e g i q r s t u w z |].include?(field[0])
     return true unless field[1] == ' '
@@ -1716,70 +1719,70 @@ module MarcCleanup
     false
   end
 
-  def text_007(field)
+  def text_f007(field)
     return true unless field.length == 1
 
     %w[a b c d u z |].include?(field[0]) ? false : true
   end
 
-  def video_007(field)
+  def video_f007(field)
     return true unless field.length == 8
     return true unless %w[c d f r u z |].include?(field[0])
     return true unless field[1] == ' '
     return true unless %w[a b c m n u z |].include?(field[2])
     return true unless field[3] =~ /[a-kmopqsuvz|]/
-    return true unless %w[\  a b u |].include?(field[4])
-    return true unless %w[\  a b c d e f g h i u z |].include?(field[5])
+    return true unless [' ', 'a', 'b', 'u', '|'].include?(field[4])
+    return true unless [' ', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'u', 'z', '|'].include?(field[5])
     return true unless %w[a m o p q r u z |].include?(field[6])
     return true unless %w[k m n q s u z |].include?(field[7])
 
     false
   end
 
-  def unspec_007(field)
+  def unspec_f007(field)
     return true unless field.length == 1
 
     %w[m u z |].include?(field[0]) ? false : true
   end
 
-  def bad_007?(record)
+  def bad_f007?(record)
     fields = record.fields('007')
     return false if fields.empty?
 
     fields.each do |field|
       rec_type = field.value[0]
-      specific_f007 = field.value[1..-1]
+      specific_f007 = field.value[1..]
       return true unless specific_f007
 
       case rec_type
       when 'a'
-        return true if map_007(specific_f007)
+        return true if map_f007(specific_f007)
       when 'c'
-        return true if elec_007(specific_f007)
+        return true if elec_f007(specific_f007)
       when 'd'
-        return true if globe_007(specific_f007)
+        return true if globe_f007(specific_f007)
       when 'f'
-        return true if tactile_007(specific_f007)
+        return true if tactile_f007(specific_f007)
       when 'g'
-        return true if proj_graphic_007(specific_f007)
+        return true if proj_graphic_f007(specific_f007)
       when 'h'
-        return true if microform_007(specific_f007)
+        return true if microform_f007(specific_f007)
       when 'k'
-        return true if nonproj_graphic_007(specific_f007)
+        return true if nonproj_graphic_f007(specific_f007)
       when 'm'
-        return true if motion_pict_007(specific_f007)
+        return true if motion_pict_f007(specific_f007)
       when 'o' || 'q'
-        return true if kit_mus_007(specific_f007)
+        return true if kit_mus_f007(specific_f007)
       when 'r'
-        return true if remote_007(specific_f007)
+        return true if remote_f007(specific_f007)
       when 's'
-        return true if recording_007(specific_f007)
+        return true if recording_f007(specific_f007)
       when 't'
-        return true if text_007(specific_f007)
+        return true if text_f007(specific_f007)
       when 'v'
-        return true if video_007(specific_f007)
+        return true if video_f007(specific_f007)
       when 'z'
-        return true if unspec_007(specific_f007)
+        return true if unspec_f007(specific_f007)
       else
         return true
       end
@@ -1787,7 +1790,7 @@ module MarcCleanup
     false
   end
 
-  def bad_008?(record)
+  def bad_f008?(record)
     hash = {}
     hash[:valid] = true
     hash[:errors] = []
@@ -1797,27 +1800,27 @@ module MarcCleanup
       'Invalid value in the specific 008 (positions 18-34)'
     ]
     field = record['008'].value
-  
+
     if field.length != 40
       hash[:valid] = false
-      hash[:errors] << errors[0] 
+      hash[:errors] << errors[0]
       return hash
     end
 
-    if all_008(field)
+    if all_f008(field)
       hash[:valid] = false
       hash[:errors] << errors[1]
     end
 
     rec_type = record.leader[6..7]
     specific_f008 = field[18..34]
-    if book.include?(rec_type) && book_008(specific_f008) ||
-      comp_file.include?(rec_type) && comp_008(specific_f008) ||
-      map.include?(rec_type) && map_008(specific_f008) ||
-      music.include?(rec_type) && music_008(specific_f008) ||
-      continuing_resource.include?(rec_type) && continuing_resource_008(specific_f008) ||
-      visual.include?(rec_type) && visual_008(specific_f008) ||
-      mixed.include?(rec_type) && mix_mat_008(specific_f008)
+    if book.include?(rec_type) && book_f008(specific_f008) ||
+       comp_file.include?(rec_type) && comp_f008(specific_f008) ||
+       map.include?(rec_type) && map_f008(specific_f008) ||
+       music.include?(rec_type) && music_f008(specific_f008) ||
+       continuing_resource.include?(rec_type) && continuing_resource_f008(specific_f008) ||
+       visual.include?(rec_type) && visual_f008(specific_f008) ||
+       mixed.include?(rec_type) && mix_mat_f008(specific_f008)
       hash[:valid] = false
       hash[:errors] << errors[2]
     end
@@ -1825,7 +1828,7 @@ module MarcCleanup
   end
 
   ### Replace obsolete values with current values when possible
-  def fix_007(record)
+  def fix_f007(record)
     target_fields = record.fields('007')
     return record if target_fields.empty?
 
@@ -1835,62 +1838,63 @@ module MarcCleanup
       rec_type = field_value[0]
       next unless %w[a c d f g h k m o q r s t v z].include? rec_type
 
-      fixed_007 = rec_type
-      specific_007 = field_value[1..-1]
-      next unless specific_007
+      specific_f007 = field_value[1..]
+      next unless specific_f007
 
+      fixed_f007 = ''.dup
+      fixed_f007 << rec_type
       case rec_type
       when 'a'
-        fixed_007 << fix_map_007(specific_007)
+        fixed_f007 << fix_map_f007(specific_f007)
       when 'c'
-        fixed_007 << fix_electronic_007(specific_007)
+        fixed_f007 << fix_electronic_f007(specific_f007)
       when 'd'
-        fixed_007 << fix_globe_007(specific_007)
+        fixed_f007 << fix_globe_f007(specific_f007)
       when 'f'
-        fixed_007 << fix_tactile_007(specific_007)
+        fixed_f007 << fix_tactile_f007(specific_f007)
       when 'g'
-        fixed_007 << fix_proj_007(specific_007)
+        fixed_f007 << fix_proj_f007(specific_f007)
       when 'h'
-        fixed_007 << fix_microform_007(specific_007)
+        fixed_f007 << fix_microform_f007(specific_f007)
       when 'k'
-        fixed_007 << fix_nonproj_007(specific_007)
+        fixed_f007 << fix_nonproj_f007(specific_f007)
       when 'm'
-        fixed_007 << fix_motion_pic_007(specific_007)
+        fixed_f007 << fix_motion_pic_f007(specific_f007)
       when 'o'
-        fixed_007 << fix_kit_007(specific_007)
+        fixed_f007 << fix_kit_f007(specific_f007)
       when 'q'
-        fixed_007 << fix_notated_mus_007(specific_007)
+        fixed_f007 << fix_notated_mus_f007(specific_f007)
       when 'r'
-        fixed_007 << fix_remote_007(specific_007)
+        fixed_f007 << fix_remote_f007(specific_f007)
       when 's'
-        fixed_007 << fix_sound_rec_007(specific_007)
+        fixed_f007 << fix_sound_rec_f007(specific_f007)
       when 't'
-        fixed_007 << fix_text_007(specific_007)
+        fixed_f007 << fix_text_f007(specific_f007)
       when 'v'
-        fixed_007 << fix_video_007(specific_007)
+        fixed_f007 << fix_video_f007(specific_f007)
       when 'z'
-        fixed_007 << fix_unspec_007(specific_007)
+        fixed_f007 << fix_unspec_f007(specific_f007)
       end
-      record.fields[field_index].value = fixed_007
+      record.fields[field_index] = MARC::ControlField.new('007', fixed_f007)
     end
     record
   end
 
-  def fix_map_007(specific_007)
-    return specific_007 unless specific_007.length == 7
+  def fix_map_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 7
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    color = specific_007[2]
-    color.gsub!('b', 'c')
-    medium = specific_007[3]
-    medium.gsub!(/[^a-gijlnp-z|]/, 'u')
-    repro_type = specific_007[4]
-    repro_type.gsub!(/[^fnuz|]/, 'u')
-    prod_details = specific_007[5]
-    prod_details.gsub!(/[^abcduz|]/, 'u')
-    aspect = specific_007[6]
-    aspect.gsub!('u', '|')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    color = specific_f007[2]
+    color = color.gsub('b', 'c')
+    medium = specific_f007[3]
+    medium = medium.gsub(/[^a-gijlnp-z|]/, 'u')
+    repro_type = specific_f007[4]
+    repro_type = repro_type.gsub(/[^fnuz|]/, 'u')
+    prod_details = specific_f007[5]
+    prod_details = prod_details.gsub(/[^abcduz|]/, 'u')
+    aspect = specific_f007[6]
+    aspect = aspect.gsub('u', '|')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -1901,70 +1905,70 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_electronic_007(specific_007)
-    return specific_007 unless specific_007.length > 4
+  def fix_electronic_f007(specific_f007)
+    return specific_f007 unless specific_f007.length > 4
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^a-fhjkmorsuz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!(/[^abcghmnuz|]/, 'u')
-    dimensions = specific_007[3]
-    dimensions.gsub!(/[^aegijnouvz|]/, 'u')
-    sound = specific_007[4]
-    sound.gsub!(/[^ au|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^a-fhjkmorsuz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub(/[^abcghmnuz|]/, 'u')
+    dimensions = specific_f007[3]
+    dimensions = dimensions.gsub(/[^aegijnouvz|]/, 'u')
+    sound = specific_f007[4]
+    sound = sound.gsub(/[^ au|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
     fixed_field << dimensions
     fixed_field << sound
-    return fixed_field if specific_007.length == 5
+    return fixed_field if specific_f007.length == 5
 
-    bit_depth = specific_007[5..7]
+    bit_depth = specific_f007[5..7]
     unless %w[mmm nnn --- |||].include? bit_depth
       bit_depth =~ /^[0-9]{3}$/ ? bit_depth : '---'
     end
     fixed_field << bit_depth
-    formats = specific_007[8]
+    formats = specific_f007[8]
     return fixed_field unless formats
 
-    formats.gsub!(/[^amu|]/, 'u')
+    formats = formats.gsub(/[^amu|]/, 'u')
     fixed_field << formats
-    quality = specific_007[9]
+    quality = specific_f007[9]
     return fixed_field unless quality
 
-    quality.gsub!(/[^anpu|]/, 'u')
+    quality = quality.gsub(/[^anpu|]/, 'u')
     fixed_field << quality
-    source = specific_007[10]
+    source = specific_f007[10]
     return fixed_field unless source
 
-    source.gsub!(/[^abcdmnu|]/, 'u')
+    source = source.gsub(/[^abcdmnu|]/, 'u')
     fixed_field << source
-    compression = specific_007[11]
+    compression = specific_f007[11]
     return fixed_field unless compression
 
-    compression.gsub!(/[^abdmu|]/, 'u')
+    compression = compression.gsub(/[^abdmu|]/, 'u')
     fixed_field << compression
-    reformatting = specific_007[12]
+    reformatting = specific_f007[12]
     return fixed_field unless reformatting
 
-    reformatting.gsub!(/[^anpru|]/, 'u')
+    reformatting = reformatting.gsub(/[^anpru|]/, 'u')
     fixed_field << reformatting
     fixed_field
   end
 
-  def fix_globe_007(specific_007)
-    return specific_007 unless specific_007.length == 5
+  def fix_globe_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 5
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^abcdeuz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!('b', 'c')
-    medium = specific_007[3]
-    medium.gsub!(/[^a-gilnpuvwz|]/, 'u')
-    repro_type = specific_007[4]
-    repro_type.gsub!(/[^fnuz|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^abcdeuz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub('b', 'c')
+    medium = specific_f007[3]
+    medium = medium.gsub(/[^a-gilnpuvwz|]/, 'u')
+    repro_type = specific_f007[4]
+    repro_type = repro_type.gsub(/[^fnuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -1973,26 +1977,26 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_tactile_007(specific_007)
-    return specific_007 unless specific_007.length == 9
+  def fix_tactile_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 9
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^abcduz|]/, 'u')
-    writing = specific_007[2..3]
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^abcduz|]/, 'u')
+    writing = specific_f007[2..3]
     unless writing == '||'
       writing_chars = writing.chars.select { |c| c =~ /[a-emnuz]/ }.sort.join('')
       writing = writing_chars.ljust(2)
     end
-    contraction = specific_007[4]
-    contraction.gsub!(/[^abmnuz|]/, 'u')
-    music = specific_007[5..7]
+    contraction = specific_f007[4]
+    contraction = contraction.gsub(/[^abmnuz|]/, 'u')
+    music = specific_f007[5..7]
     unless music == '|||'
       music_chars = music.chars.select { |c| c =~ /[a-lnuz]/ }.sort.join('')
       music = music_chars.ljust(3)
     end
-    special = specific_007[8]
-    special.gsub!(/[^abnuz|]/, 'u')
+    special = specific_f007[8]
+    special = special.gsub(/[^abnuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << writing
@@ -2002,24 +2006,24 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_proj_007(specific_007)
-    return specific_007 unless specific_007.length == 8
+  def fix_proj_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 8
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^cdfostuz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!(/[^abchmnuz|]/, 'u')
-    base = specific_007[3]
-    base.gsub!(/[^dejkmouz|]/, 'u')
-    sound_on_medium = specific_007[4]
-    sound_on_medium.gsub!(/[^ abu|]/, 'u')
-    sound_medium = specific_007[5]
-    sound_medium.gsub!(/[^ a-iuz|]/, 'u')
-    dimensions = specific_007[6]
-    dimensions.gsub!(/[^a-gjkst-z|]/, 'u')
-    support = specific_007[7]
-    support.gsub!(/[^ cdehjkmuz|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^cdfostuz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub(/[^abchmnuz|]/, 'u')
+    base = specific_f007[3]
+    base = base.gsub(/[^dejkmouz|]/, 'u')
+    sound_on_medium = specific_f007[4]
+    sound_on_medium = sound_on_medium.gsub(/[^ abu|]/, 'u')
+    sound_medium = specific_f007[5]
+    sound_medium = sound_medium.gsub(/[^ a-iuz|]/, 'u')
+    dimensions = specific_f007[6]
+    dimensions = dimensions.gsub(/[^a-gjkst-z|]/, 'u')
+    support = specific_f007[7]
+    support = support.gsub(/[^ cdehjkmuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -2031,32 +2035,31 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_microform_007(specific_007)
-    return specific_007 unless specific_007.length == 12
+  def fix_microform_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 12
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^a-hjuz|]/, 'u')
-    aspect = specific_007[2]
-    aspect.gsub!(/[^abmu|]/, 'u')
-    dimensions = specific_007[3]
-    dimensions.gsub!(/[^adfghlmopuz|]/, 'u')
-    reduction_range = specific_007[4]
-    reduction_range.gsub!(/[^a-euv|]/, 'u')
-    reduction_ratio = specific_007[5..7]
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^a-hjuz|]/, 'u')
+    aspect = specific_f007[2]
+    aspect = aspect.gsub(/[^abmu|]/, 'u')
+    dimensions = specific_f007[3]
+    dimensions = dimensions.gsub(/[^adfghlmopuz|]/, 'u')
+    reduction_range = specific_f007[4]
+    reduction_range = reduction_range.gsub(/[^a-euv|]/, 'u')
+    reduction_ratio = specific_f007[5..7]
     unless %w[--- |||].include? reduction_ratio
-      reduction_ratio =~ /^[0-9]/ ? reduction_ratio : '---'
       reduction_nums = reduction_ratio.chars.select { |c| c =~ /[0-9]/ }.join('')
       reduction_ratio = reduction_nums.ljust(3, '-')
     end
-    color = specific_007[8]
-    color.gsub!(/[^bcmuz|]/, 'u')
-    emulsion = specific_007[9]
-    emulsion.gsub!(/[^abcmnuz|]/, 'u')
-    generation = specific_007[10]
-    generation.gsub!(/[^abcmu|]/, 'u')
-    base = specific_007[11]
-    base.gsub!(/[^abcdimnprtuz|]/, 'u')
+    color = specific_f007[8]
+    color = color.gsub(/[^bcmuz|]/, 'u')
+    emulsion = specific_f007[9]
+    emulsion = emulsion.gsub(/[^abcmnuz|]/, 'u')
+    generation = specific_f007[10]
+    generation = generation.gsub(/[^abcmu|]/, 'u')
+    base = specific_f007[11]
+    base = base.gsub(/[^abcdimnprtuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << aspect
@@ -2070,18 +2073,18 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_nonproj_007(specific_007)
-    return specific_007 unless specific_007.length == 5
+  def fix_nonproj_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 5
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^ac-ln-suvz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!(/[^abchmuz|]/, 'u')
-    primary_support = specific_007[3]
-    primary_support.gsub!(/[^a-il-wz|]/, 'u')
-    secondary_support = specific_007[4]
-    secondary_support.gsub!(/[^ a-il-wz|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^ac-ln-suvz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub(/[^abchmuz|]/, 'u')
+    primary_support = specific_f007[3]
+    primary_support = primary_support.gsub(/[^a-il-wz|]/, 'u')
+    secondary_support = specific_f007[4]
+    secondary_support = secondary_support.gsub(/[^ a-il-wz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -2090,22 +2093,22 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_motion_pic_007(specific_007)
-    return specific_007 unless specific_007.length > 6
+  def fix_motion_pic_f007(specific_f007)
+    return specific_f007 unless specific_f007.length > 6
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^cdforuz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!(/[^bchmnuz|]/, 'u')
-    presentation = specific_007[3]
-    presentation.gsub!(/[^a-fuz|]/, 'u')
-    sound_on_medium = specific_007[4]
-    sound_on_medium.gsub!(/[^ abu|]/, 'u')
-    sound_medium = specific_007[5]
-    sound_medium.gsub!(/[^ a-iuz|]/, 'u')
-    dimensions = specific_007[6]
-    dimensions.gsub!(/[^a-guz|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^cdforuz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub(/[^bchmnuz|]/, 'u')
+    presentation = specific_f007[3]
+    presentation = presentation.gsub(/[^a-fuz|]/, 'u')
+    sound_on_medium = specific_f007[4]
+    sound_on_medium = sound_on_medium.gsub(/[^ abu|]/, 'u')
+    sound_medium = specific_f007[5]
+    sound_medium = sound_medium.gsub(/[^ a-iuz|]/, 'u')
+    dimensions = specific_f007[6]
+    dimensions = dimensions.gsub(/[^a-guz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -2113,89 +2116,89 @@ module MarcCleanup
     fixed_field << sound_on_medium
     fixed_field << sound_medium
     fixed_field << dimensions
-    return fixed_field if specific_007.length == 7
+    return fixed_field if specific_f007.length == 7
 
-    channels = specific_007[7]
-    channels.gsub!(/[^kmnqsuz|]/, 'u')
+    channels = specific_f007[7]
+    channels = channels.gsub(/[^kmnqsuz|]/, 'u')
     fixed_field << channels
-    elements = specific_007[8]
+    elements = specific_f007[8]
     return fixed_field unless elements
 
-    elements.gsub!('h', 'z')
-    elements.gsub!(/[^abcdefgnz|]/, '|')
+    elements = elements.gsub('h', 'z')
+    elements = elements.gsub(/[^abcdefgnz|]/, '|')
     fixed_field << elements
-    aspect = specific_007[9]
+    aspect = specific_f007[9]
     return fixed_field unless aspect
 
-    aspect.gsub!(/[^abnuz|]/, 'u')
+    aspect = aspect.gsub(/[^abnuz|]/, 'u')
     fixed_field << aspect
-    generation = specific_007[10]
+    generation = specific_f007[10]
     return fixed_field unless generation
 
-    generation.gsub!(/[^deoruz|]/, 'u')
+    generation = generation.gsub(/[^deoruz|]/, 'u')
     fixed_field << generation
-    base = specific_007[11]
+    base = specific_f007[11]
     return fixed_field unless base
 
-    base.gsub!(/[^acdimnprtuz|]/, 'u')
+    base = base.gsub(/[^acdimnprtuz|]/, 'u')
     fixed_field << base
-    refined = specific_007[12]
+    refined = specific_f007[12]
     return fixed_field unless refined
 
-    refined.gsub!(/[^a-np-vz|]/, 'u')
+    refined = refined.gsub(/[^a-np-vz|]/, 'u')
     fixed_field << refined
-    stock = specific_007[13]
+    stock = specific_f007[13]
     return fixed_field unless stock
 
-    stock.gsub!(/[^abcdnuz|]/, 'u')
+    stock = stock.gsub(/[^abcdnuz|]/, 'u')
     fixed_field << stock
-    deterioration = specific_007[14]
+    deterioration = specific_f007[14]
     return fixed_field unless deterioration
 
-    deterioration.gsub!(/[^abcdefghklm|]/, '|')
+    deterioration = deterioration.gsub(/[^abcdefghklm|]/, '|')
     fixed_field << deterioration
-    completeness = specific_007[15]
+    completeness = specific_f007[15]
     return fixed_field unless completeness
 
-    completeness.gsub!(/[^cinu|]/, 'u')
+    completeness = completeness.gsub(/[^cinu|]/, 'u')
     fixed_field << completeness
-    return fixed_field if specific_007.length == 16
+    return fixed_field if specific_f007.length == 16
 
-    inspect_date = specific_007[16..21]
-    inspect_date.gsub!(/[^0-9\-]/, '-')
+    inspect_date = specific_f007[16..21]
+    inspect_date = inspect_date.gsub(/[^0-9-]/, '-')
     fixed_field << inspect_date
     fixed_field
   end
 
-  def fix_kit_007(specific_007)
-    mat_designation = specific_007[0]
+  def fix_kit_f007(specific_f007)
+    mat_designation = specific_f007[0]
     mat_designation.gsub(/[^u|]/, 'u')
   end
 
-  def fix_notated_mus_007(specific_007)
-    mat_designation = specific_007[0]
+  def fix_notated_mus_f007(specific_f007)
+    mat_designation = specific_f007[0]
     mat_designation.gsub(/[^u|]/, 'u')
   end
 
-  def fix_remote_007(specific_007)
-    return specific_007 unless specific_007.length == 10
+  def fix_remote_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 10
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^u|]/, 'u')
-    altitude = specific_007[2]
-    altitude.gsub!(/[^abcnuz|]/, 'u')
-    attitude = specific_007[3]
-    attitude.gsub!(/[^abcnuz|]/, 'u')
-    clouds = specific_007[4]
-    clouds.gsub!(/[^0-9nu|]/, 'u')
-    construction = specific_007[5]
-    construction.gsub!(/[^a-inuz|]/, 'u')
-    use = specific_007[6]
-    use.gsub!(/[^abcmnuz|]/, 'u')
-    sensor = specific_007[7]
-    sensor.gsub!(/[^abuz|]/, 'u')
-    data_type = specific_007[8..9]
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^u|]/, 'u')
+    altitude = specific_f007[2]
+    altitude = altitude.gsub(/[^abcnuz|]/, 'u')
+    attitude = specific_f007[3]
+    attitude = attitude.gsub(/[^abcnuz|]/, 'u')
+    clouds = specific_f007[4]
+    clouds = clouds.gsub(/[^0-9nu|]/, 'u')
+    construction = specific_f007[5]
+    construction = construction.gsub(/[^a-inuz|]/, 'u')
+    use = specific_f007[6]
+    use = use.gsub(/[^abcmnuz|]/, 'u')
+    sensor = specific_f007[7]
+    sensor = sensor.gsub(/[^abuz|]/, 'u')
+    data_type = specific_f007[8..9]
     data_type = 'uu' unless remote_data_types.include? data_type
     fixed_field << mat_designation
     fixed_field << ' '
@@ -2209,11 +2212,11 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_sound_rec_007(specific_007)
-    return specific_007 unless specific_007.length == 13
+  def fix_sound_rec_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 13
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0].dup
     mat_designation = case mat_designation
                       when 'c'
                         'e'
@@ -2222,16 +2225,16 @@ module MarcCleanup
                       else
                         mat_designation
                       end
-    mat_designation.gsub!(/[^degiq-uwz|]/, 'u')
-    speed = specific_007[2]
-    speed.gsub!(/[^a-fhik-pruz|]/, 'u')
-    channels = specific_007[3]
-    channels.gsub!(/[^mqsuz|]/, 'u')
-    groove = specific_007[4]
-    groove.gsub!(/[^mnsuz|]/, 'u')
-    dimensions = specific_007[5]
-    dimensions.gsub!(/[^abcdefgjnosuz|]/, 'u')
-    width = specific_007[6]
+    mat_designation = mat_designation.gsub(/[^degiq-uwz|]/, 'u')
+    speed = specific_f007[2]
+    speed = speed.gsub(/[^a-fhik-pruz|]/, 'u')
+    channels = specific_f007[3]
+    channels = channels.gsub(/[^mqsuz|]/, 'u')
+    groove = specific_f007[4]
+    groove = groove.gsub(/[^mnsuz|]/, 'u')
+    dimensions = specific_f007[5]
+    dimensions = dimensions.gsub(/[^abcdefgjnosuz|]/, 'u')
+    width = specific_f007[6]
     width = case width
             when 'a'
               'm'
@@ -2242,19 +2245,19 @@ module MarcCleanup
             else
               width
             end
-    width.gsub!(/[^l-puz|]/, 'u')
-    configuration = specific_007[7]
-    configuration.gsub!(/[^abcdefnuz|]/, 'u')
-    disc_kind = specific_007[8]
-    disc_kind.gsub!(/[^abdimnrstuz|]/, 'u')
-    material = specific_007[9]
-    material.gsub!(/[^abcgilmnprswuz|]/, 'u')
-    cutting = specific_007[10]
-    cutting.gsub!(/[^hlnu|]/, 'u')
-    playback = specific_007[11]
-    playback.gsub!(/[^abcdefghnuz|]/, 'u')
-    storage = specific_007[12]
-    storage.gsub!(/[^abdeuz|]/, 'u')
+    width = width.gsub(/[^l-puz|]/, 'u')
+    configuration = specific_f007[7]
+    configuration = configuration.gsub(/[^abcdefnuz|]/, 'u')
+    disc_kind = specific_f007[8]
+    disc_kind = disc_kind.gsub(/[^abdimnrstuz|]/, 'u')
+    material = specific_f007[9]
+    material = material.gsub(/[^abcgilmnprswuz|]/, 'u')
+    cutting = specific_f007[10]
+    cutting = cutting.gsub(/[^hlnu|]/, 'u')
+    playback = specific_f007[11]
+    playback = playback.gsub(/[^abcdefghnuz|]/, 'u')
+    storage = specific_f007[12]
+    storage = storage.gsub(/[^abdeuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << speed
@@ -2271,29 +2274,29 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_text_007(specific_007)
-    mat_designation = specific_007[0]
+  def fix_text_f007(specific_f007)
+    mat_designation = specific_f007[0]
     mat_designation.gsub(/[^abcduz|]/, 'u')
   end
 
-  def fix_video_007(specific_007)
-    return specific_007 unless specific_007.length == 8
+  def fix_video_f007(specific_f007)
+    return specific_f007 unless specific_f007.length == 8
 
-    fixed_field = ''
-    mat_designation = specific_007[0]
-    mat_designation.gsub!(/[^cdfruz|]/, 'u')
-    color = specific_007[2]
-    color.gsub!(/[^abcmnuz|]/, 'u')
-    format = specific_007[3]
-    format.gsub!(/[^a-kmopqsuvz|]/, 'u')
-    sound_on_medium = specific_007[4]
-    sound_on_medium.gsub!(/[^ abu|]/, 'u')
-    sound_medium = specific_007[5]
-    sound_medium.gsub!(/[^ abcdefghiuz|]/, 'u')
-    dimensions = specific_007[6]
-    dimensions.gsub!(/[^amopqruz|]/, 'u')
-    channels = specific_007[7]
-    channels.gsub!(/[^kmnqsuz|]/, 'u')
+    fixed_field = ''.dup
+    mat_designation = specific_f007[0]
+    mat_designation = mat_designation.gsub(/[^cdfruz|]/, 'u')
+    color = specific_f007[2]
+    color = color.gsub(/[^abcmnuz|]/, 'u')
+    format = specific_f007[3]
+    format = format.gsub(/[^a-kmopqsuvz|]/, 'u')
+    sound_on_medium = specific_f007[4]
+    sound_on_medium = sound_on_medium.gsub(/[^ abu|]/, 'u')
+    sound_medium = specific_f007[5]
+    sound_medium = sound_medium.gsub(/[^ abcdefghiuz|]/, 'u')
+    dimensions = specific_f007[6]
+    dimensions = dimensions.gsub(/[^amopqruz|]/, 'u')
+    channels = specific_f007[7]
+    channels = channels.gsub(/[^kmnqsuz|]/, 'u')
     fixed_field << mat_designation
     fixed_field << ' '
     fixed_field << color
@@ -2305,8 +2308,8 @@ module MarcCleanup
     fixed_field
   end
 
-  def fix_unspec_007(specific_007)
-    mat_designation = specific_007[0]
+  def fix_unspec_f007(specific_f007)
+    mat_designation = specific_f007[0]
     mat_designation.gsub(/[^muz|]/, 'u')
   end
 
@@ -2334,85 +2337,86 @@ module MarcCleanup
   end
 
   ### Replace obsolete values with current values when possible
-  def fix_006(record)
-    target_fields = record.fields('006')
-    return record if target_fields.empty?
-
-    target_fields.each do |field|
+  def fix_f006(record)
+    record.fields.each_with_index do |field, field_index|
+      next unless field.tag == '006'
       next if field.value.size != 18
 
       rec_type = field.value[0]
       next unless rec_type =~ /[ac-gijkmoprst]/
 
-      specific_006 = field.value[1..-1]
-      field.value[1..-1] = case rec_type
-                           when 'a', 't'
-                             fix_book_008(specific_006)
-                           when 'c', 'd', 'i', 'j'
-                             fix_music_008(specific_006)
-                           when 'e', 'f'
-                             fix_map_008(specific_006)
-                           when 'g', 'k', 'o', 'r'
-                             fix_visual_008(specific_006)
-                           when 'm'
-                             fix_comp_008(specific_006)
-                           when 'p'
-                             fix_mix_mat_008(specific_006)
-                           when 's'
-                             fix_continuing_resource_008(specific_006)
-                           end
+      new_value = rec_type
+      specific_f006 = field.value[1..]
+      fixed_specific_f006 = case rec_type
+                            when 'a', 't'
+                              fix_book_f008(specific_f006)
+                            when 'c', 'd', 'i', 'j'
+                              fix_music_f008(specific_f006)
+                            when 'e', 'f'
+                              fix_map_f008(specific_f006)
+                            when 'g', 'k', 'o', 'r'
+                              fix_visual_f008(specific_f006)
+                            when 'm'
+                              fix_comp_f008(specific_f006)
+                            when 'p'
+                              fix_mix_mat_f008(specific_f006)
+                            when 's'
+                              fix_continuing_resource_f008(specific_f006)
+                            end
+      new_value << fixed_specific_f006
+      record.fields[field_index] = MARC::ControlField.new('006', new_value)
     end
     record
   end
 
   ### Replace obsolete values with current values when possible
-  def fix_008(record)
+  def fix_f008(record)
     target_fields = record.fields('008')
-    return record if target_fields.size != 1
-
     rec_type = record.leader[6..7]
+    return record if target_fields.size != 1
     return record unless rec_type =~ /^[ac-gijkmoprt][abcdims]$/
 
-    fixed_record = record
     field = target_fields.first
     return record if field.value.size != 40
 
-    field_index = fixed_record.fields.index(field)
-    field_value = field.value
-    specific_008 = field_value[18..34]
-    modified = field_value[38]
-    cat_source = field_value[39]
-    fixed_008 = field_value
-    fixed_008[38] = '|' if modified == 'u'
-    if cat_source =~ /[abl]/
-      fixed_008[39] = ' '
-    elsif [' ', 'c', 'd', 'u', '|'].include? cat_source
-      fixed_008[39] = cat_source
-    elsif cat_source == 'o'
-      fixed_008[39] = 'd'
-    end
-    fixed_008[18..34] =
-      if book.include? rec_type
-        fix_book_008(specific_008)
-      elsif comp_file.include? rec_type
-        fix_comp_008(specific_008)
-      elsif map.include? rec_type
-        fix_map_008(specific_008)
-      elsif music.include? rec_type
-        fix_music_008(specific_008)
-      elsif continuing_resource.include? rec_type
-        fix_continuing_resource_008(specific_008)
-      elsif visual.include? rec_type
-        fix_visual_008(specific_008)
-      elsif mixed.include? rec_type
-        fix_mix_mat_008(specific_008)
-      end
-    fixed_record.fields[field_index].value = fixed_008
-    fixed_record
+    field_index = record.fields.index(field)
+    new_value = field.value[0..17]
+    specific_f008 = field.value[18..34]
+    fixed_specific_f008 = if book.include? rec_type
+                            fix_book_f008(specific_f008)
+                          elsif comp_file.include? rec_type
+                            fix_comp_f008(specific_f008)
+                          elsif map.include? rec_type
+                            fix_map_f008(specific_f008)
+                          elsif music.include? rec_type
+                            fix_music_f008(specific_f008)
+                          elsif continuing_resource.include? rec_type
+                            fix_continuing_resource_f008(specific_f008)
+                          elsif visual.include? rec_type
+                            fix_visual_f008(specific_f008)
+                          elsif mixed.include? rec_type
+                            fix_mix_mat_f008(specific_f008)
+                          end
+    new_value << fixed_specific_f008
+    new_value << field.value[35..37]
+    modified = field.value[38]
+    modified = '|' if modified == 'u'
+    new_value << modified
+    cat_source = field.value[39]
+    new_value << case cat_source
+                 when 'a', 'b', 'l'
+                   ' '
+                 when 'o'
+                   'd'
+                 else
+                   cat_source
+                 end
+    record.fields[field_index] = MARC::ControlField.new('008', new_value)
+    record
   end
 
-  def fix_book_008(field)
-    fixed_field = ''
+  def fix_book_f008(field)
+    fixed_field = ''.dup
     illus = field[0..3]
     audience = field[4]
     item_form = field[5]
@@ -2428,44 +2432,44 @@ module MarcCleanup
       illus = illus_chars.ljust(4)
     end
     fixed_field << illus
-    audience.gsub!(/[uv]/, 'j')
+    audience = audience.gsub(/[uv]/, 'j')
     fixed_field << audience
     fixed_field << item_form
     contents = fix_contents_chars(contents)
     fixed_field << contents
-    gov_pub.gsub!('n', 'o')
+    gov_pub = gov_pub.gsub('n', 'o')
     fixed_field << gov_pub
     fixed_field << conf_pub
     fixed_field << festschrift
     fixed_field << index_code
     fixed_field << ' '
-    lit_form.gsub!(' ', '0')
+    lit_form = lit_form.gsub(' ', '0')
     fixed_field << lit_form
     fixed_field << biog
     fixed_field.gsub('-', '|')
   end
 
-  def fix_comp_008(field)
-    fixed_field = ''
+  def fix_comp_f008(field)
+    fixed_field = ''.dup
     audience = field[4]
     item_form = field[5]
     type = field[8]
     gov_pub = field[10]
     fixed_field << '    '
-    audience.gsub!(/[uv]/, 'j')
+    audience = audience.gsub(/[uv]/, 'j')
     fixed_field << audience
     fixed_field << item_form
     fixed_field << '  '
     fixed_field << type
     fixed_field << ' '
-    gov_pub.gsub!('n', 'o')
+    gov_pub = gov_pub.gsub('n', 'o')
     fixed_field << gov_pub
     fixed_field << '      '
     fixed_field.gsub('-', '|')
   end
 
-  def fix_map_008(field)
-    fixed_field = ''
+  def fix_map_f008(field)
+    fixed_field = ''.dup
     relief = field[0..3]
     proj = field[4..5]
     type = field[7]
@@ -2474,7 +2478,7 @@ module MarcCleanup
     index_code = field[13]
     format = field[15..16]
     unless relief == '||||'
-      relief.gsub!('h', 'c')
+      relief = relief.gsub('h', 'c')
       relief_chars = relief.chars.select { |c| %w[a b c d e f g i j k m z].include? c }.sort.join('')
       relief = relief_chars.ljust(4)
     end
@@ -2483,7 +2487,7 @@ module MarcCleanup
     fixed_field << ' '
     fixed_field << type
     fixed_field << '  '
-    gov_pub.gsub!('n', 'o')
+    gov_pub = gov_pub.gsub('n', 'o')
     fixed_field << gov_pub
     fixed_field << item_form
     fixed_field << ' '
@@ -2497,8 +2501,8 @@ module MarcCleanup
     fixed_field.gsub('-', '|')
   end
 
-  def fix_music_008(field)
-    fixed_field = ''
+  def fix_music_f008(field)
+    fixed_field = ''.dup
     comp_form = field[0..1]
     music_format = field[2]
     parts = field[3]
@@ -2510,17 +2514,19 @@ module MarcCleanup
     fixed_field << comp_form
     fixed_field << music_format
     fixed_field << parts
-    audience.gsub!(/[uv]/, 'j')
+    audience = audience.gsub(/[uv]/, 'j')
     fixed_field << audience
     fixed_field << item_form
     unless accompanying == '||||||'
-      accompanying.gsub!('j', 'i')
+      accompanying = accompanying.gsub('j', 'i')
       accompanying_chars = accompanying.chars.select { |c| %w[a b c d e f g h i k r s z].include? c }.sort.join('')
       accompanying = accompanying_chars.ljust(6)
     end
     fixed_field << accompanying
     unless ['||', '  '].include? lit_text
-      lit_text_chars = lit_text.chars.select { |c| %w[a b c d e f g h i j k l m n o p r s t z].include? c }.sort.join('')
+      lit_text_chars = lit_text.chars.select do |c|
+        %w[a b c d e f g h i j k l m n o p r s t z].include? c
+      end.sort.join('')
       lit_text = lit_text_chars.ljust(2)
     end
     fixed_field << lit_text
@@ -2530,8 +2536,8 @@ module MarcCleanup
     fixed_field.gsub('-', '|')
   end
 
-  def fix_continuing_resource_008(field)
-    fixed_field = ''
+  def fix_continuing_resource_f008(field)
+    fixed_field = ''.dup
     freq = field[0]
     reg = field[1]
     cr_type = field[3]
@@ -2552,7 +2558,7 @@ module MarcCleanup
     fixed_field << work_nature
     contents = fix_contents_chars(contents)
     fixed_field << contents
-    gov_pub.gsub!('n', 'o')
+    gov_pub = gov_pub.gsub('n', 'o')
     fixed_field << gov_pub
     fixed_field << conf_pub
     fixed_field << '   '
@@ -2561,8 +2567,8 @@ module MarcCleanup
     fixed_field.gsub('-', '|')
   end
 
-  def fix_visual_008(field)
-    fixed_field = ''
+  def fix_visual_f008(field)
+    fixed_field = ''.dup
     runtime = field[0..2]
     audience = field[4]
     gov_pub = field[10]
@@ -2571,22 +2577,22 @@ module MarcCleanup
     technique = field[16]
     fixed_field << runtime
     fixed_field << ' '
-    audience.gsub!(/[uv]/, 'j')
+    audience = audience.gsub(/[uv]/, 'j')
     fixed_field << audience
     fixed_field << '     '
-    gov_pub.gsub!('n', 'o')
+    gov_pub = gov_pub.gsub('n', 'o')
     fixed_field << gov_pub
     fixed_field << item_form
     fixed_field << '   '
-    visual_type.gsub!('e', 'v')
+    visual_type = visual_type.gsub('e', 'v')
     fixed_field << visual_type
-    technique.gsub!(' ', 'n')
+    technique = technique.gsub(' ', 'n')
     fixed_field << technique
     fixed_field
   end
 
-  def fix_mix_mat_008(field)
-    fixed_field = ''
+  def fix_mix_mat_f008(field)
+    fixed_field = ''.dup
     item_form = field[5]
     fixed_field << '     '
     fixed_field << item_form

--- a/spec/fixed_fields/005_spec.rb
+++ b/spec/fixed_fields/005_spec.rb
@@ -3,14 +3,14 @@ require 'marc'
 require 'byebug'
 require 'marc_cleanup'
 
-RSpec.describe 'bad_005?' do
+RSpec.describe 'bad_f005?' do
 
   context 'when an 005 field is valid' do
     let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
     let(:leader) { '01104naa a2200289 i 4500' }
     let(:fields) { [ { '005' => '19940223151047.0' } ] }
-  
-    it { expect(MarcCleanup.bad_005?(record)).to eq false }
+
+    it { expect(MarcCleanup.bad_f005?(record)).to eq false }
   end
 
   context 'when an 005 is not valid' do
@@ -18,14 +18,14 @@ RSpec.describe 'bad_005?' do
     let(:leader) { '01104naa a2200289 i 4500' }
     let(:fields) { [ { '005' => '199402231510470' } ] }
   
-    it { expect(MarcCleanup.bad_005?(record)).to eq true }
+    it { expect(MarcCleanup.bad_f005?(record)).to eq true }
   end
-  
+
   context 'when an 005 is not present' do
     let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
     let(:leader) { '01104naa a2200289 i 4500' }
     let(:fields) { [ { '001' => '199402231510470' } ] }
 
-    it { expect(MarcCleanup.bad_005?(record)).to eq false }
+    it { expect(MarcCleanup.bad_f005?(record)).to eq false }
   end
 end

--- a/spec/fixed_fields/006_spec.rb
+++ b/spec/fixed_fields/006_spec.rb
@@ -6,19 +6,19 @@ require 'marc_cleanup'
 RSpec.describe 'field 006 methods' do
   let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
 
-  describe "bad_006?" do
+  describe 'bad_f006?' do
 
     describe 'book format' do
       let(:leader) { '01104naa a2200289 i 4500' }
 
       context 'when the 006 field is valid' do
-        let(:fields) { [ { '006' => 'a    fsf   |001 0 ' } ] } 
-        it {expect(MarcCleanup.bad_006?(record)).to eq false }
+        let(:fields) { [ { '006' => 'a    fsf   |001 0 ' } ] }
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
-        let(:fields) { [ { '006' => 'a    fsf   |001 3 ' } ] } 
-        it {expect(MarcCleanup.bad_006?(record)).to eq true }
+        let(:fields) { [ { '006' => 'a    fsf   |001 3 ' } ] }
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
     end
 
@@ -27,12 +27,12 @@ RSpec.describe 'field 006 methods' do
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 'm    fo  b |      ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false }                
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 'm    fo  b |     x' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true }  
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
     end
 
@@ -41,12 +41,12 @@ RSpec.describe 'field 006 methods' do
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 'eb   aa a  aa 0   ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 'eb   aa a  aa l   ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
     end
 
@@ -55,12 +55,12 @@ RSpec.describe 'field 006 methods' do
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 'canadaaa     a  a ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 'canadaaa     a  l ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
     end
 
@@ -69,12 +69,12 @@ RSpec.describe 'field 006 methods' do
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 's | |||||||a0    0' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false }
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 's | |||||||a0    3' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
     end
 
@@ -83,107 +83,107 @@ RSpec.describe 'field 006 methods' do
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 'g135 f     fs   ma' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false }
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 'g135 f     fs   mb' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
-    end    
+    end
 
     describe 'mixed materials format' do
       let(:leader) { '01104npa a2200289 i 4500' }
 
       context 'when the 006 field is valid' do
         let(:fields) { [ { '006' => 'p     a           ' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq false }
+        it {expect(MarcCleanup.bad_f006?(record)).to eq false }
       end
 
       context 'when the 006 field is invalid' do
         let(:fields) { [ { '006' => 'p     a          9' } ] }
-        it {expect(MarcCleanup.bad_006?(record)).to eq true } 
+        it {expect(MarcCleanup.bad_f006?(record)).to eq true }
       end
-    end    
+    end
   end
 
-  describe 'fix_006' do
+  describe 'fix_f006' do
 
     describe 'fix book format 006' do
       let(:leader) { '01104naa a2200289 i 4500' }
       let(:fields) do
-        [ 
+        [
           { '006' => 'a    fsf   n001 0 ' },
-          { '008' => '230519s1996    njua          000 0 eng  ' } 
-        ] 
+          { '008' => '230519s1996    njua          000 0 eng  ' }
+        ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'a    fsf   o001 0 ' }
+      it { expect(fix_f006(record)['006'].value).to eq 'a    fsf   o001 0 ' }
     end
 
     describe 'fix computer format 006' do
       let(:leader) { '01104nma a2200289 i 4500' }
       let(:fields) do
-        [ 
-          { '006' => 'm    fo  b |     x' }, 
+        [
+          { '006' => 'm    fo  b |     x' },
           { '008' => '230519s1996    nju                 eng d' }
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'm    fo  b |      ' }
+      it { expect(fix_f006(record)['006'].value).to eq 'm    fo  b |      ' }
     end
 
     describe 'fix map format 006' do
       let(:leader) { '01104nea a2200289 i 4500' }
-      let(:fields) do 
-        [ 
+      let(:fields) do
+        [
           { '006' => 'eb   aa a  na l   ' },
           { '008' => '230519s1996    njua          0 0   eng d' }
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'eb   aa a  oa l   ' }
+      it { expect(fix_f006(record)['006'].value).to eq 'eb   aa a  oa l   ' }
     end
 
     describe 'fix music format 006' do
-      let(:leader) { '01104nca a2200289 i 4500' } 
-      let(:fields) do 
-        [ 
-          { '006' => 'canadaaa     a  l-' }, 
+      let(:leader) { '01104nca a2200289 i 4500' }
+      let(:fields) do
+        [
+          { '006' => 'canadaaa     a  l-' },
           { '008' => '230519s1996    njua              0 eng d' }
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'canadaaa     a  l ' }
+      it { expect(fix_f006(record)['006'].value).to eq 'canadaaa     a  l ' }
     end
 
     describe 'fix continuing resource format 006' do
-      let(:leader) { '01104nab a2200289 i 4500' } 
-      let(:fields) do 
-        [ 
+      let(:leader) { '01104nab a2200289 i 4500' }
+      let(:fields) do
+        [
           { '006' => 's | |||||||n0    |' },
-          { '008' => '230519s1996    njua          0   0 eng d'} 
+          { '008' => '230519s1996    njua          0   0 eng d'}
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 's | |||||||o0    |' }
+      it { expect(fix_f006(record)['006'].value).to eq 's | |||||||o0    |' }
     end
 
     describe 'fix visual format 006' do
-      let(:leader) { '01104nga a2200289 i 4500' } 
-      let(:fields) do 
-        [ 
+      let(:leader) { '01104nga a2200289 i 4500' }
+      let(:fields) do
+        [
           { '006' => 'g135 f     ns   mb' },
           { '008' => '230519s1996    njua          000 0 eng d' }
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'g135 f     os   mb' }
-    end    
+      it { expect(fix_f006(record)['006'].value).to eq 'g135 f     os   mb' }
+    end
 
     describe 'fix mixed materials format 006' do
       let(:leader) { '01104npa a2200289 i 4500' }
       let(:fields) do
-        [ 
+        [
           { '006' => 'p     a          9' },
-          { '088' => '230519s1996    njua          000 0 eng d' } 
+          { '088' => '230519s1996    njua          000 0 eng d' }
         ]
       end
-      it { expect(fix_006(record)['006'].value).to eq 'p     a           ' }
-    end 
+      it { expect(fix_f006(record)['006'].value).to eq 'p     a           ' }
+    end
   end
 end

--- a/spec/fixed_fields/007_spec.rb
+++ b/spec/fixed_fields/007_spec.rb
@@ -6,333 +6,333 @@ require 'marc_cleanup'
 RSpec.describe 'fields 007 methods' do
   let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
 
-  describe 'bad_007?' do
-    
-    describe 'map_007' do
+  describe 'bad_f007?' do
+
+    describe 'map_f007' do
      let(:leader) { '01104nea a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'aj canzn' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'ajzcanzn' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'elec_007' do
+    describe 'elec_f007' do
       let(:leader) { '01104nma a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'ca aaa001aaaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'caaaaa001aaaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'globe_007' do
+    describe 'globe_f007' do
       let(:leader) { '01104nea a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'db cif' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'dbacif' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'tactile_007' do
+    describe 'tactile_f007' do
       let(:leader) { '01104npa a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'fb a bnnnu' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'fbza bnnnu' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'proj_graphic_007' do
+    describe 'proj_graphic_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'gc cebda ' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'gcacebda ' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'microform_007' do
+    describe 'microform_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'he bmb024baaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'hezbmb024aaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'nonproj_graphic_007' do
+    describe 'nonproj_graphic_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'kh coo' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'khacoo' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'motion_pict_007' do
+    describe 'motion_pict_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
 
         context 'when the inspect_date is numerical' do
           let(:fields) { [ { '007' => 'mr bf  fnnartnnai198512' } ] }
-          it { expect(MarcCleanup.bad_007?(record)).to eq false }
+          it { expect(MarcCleanup.bad_f007?(record)).to eq false }
         end
 
         context 'when the inspect_date is |||||| or ------' do
           let(:fields) { [ { '007' => 'mr bf  fnnartnnai||||||' } ] }
-          it { expect(MarcCleanup.bad_007?(record)).to eq false }
+          it { expect(MarcCleanup.bad_f007?(record)).to eq false }
         end
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'mr bf  fnnartnnaiaaaaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'kit_mus_007' do
+    describe 'kit_mus_f007' do
       let(:leader) { '01104nca a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'ou' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'oz' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'remote_007' do
+    describe 'remote_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'ru aa0aaaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'ruaaa0aaaaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'recording_007' do
+    describe 'recording_f007' do
       let(:leader) { '01104npa a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'sd ammamaaahaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'sdaammamaaahaa' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'text_007' do
+    describe 'text_f007' do
       let(:leader) { '01104naa a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'ta' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'te' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'video_007' do
+    describe 'video_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'vc aaaaok' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'vcaaaaaok' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
-    describe 'unspec_007' do
+    describe 'unspec_f007' do
       let(:leader) { '01104nab a2200289 i 4500' }
-    
+
       context 'when the 007 is valid' do
         let(:fields) { [ { '007' => 'zu' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq false }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq false }
       end
 
       context 'when the 007 is invalid' do
         let(:fields) { [ { '007' => 'za' } ] }
-        it { expect(MarcCleanup.bad_007?(record)).to eq true }
+        it { expect(MarcCleanup.bad_f007?(record)).to eq true }
       end
     end
 
     describe '007 with non valid category' do
       let(:leader) { '01104nab a2200289 i 4500' }
       let(:fields) { [ { '007' => 'wa' } ] }
-      it { expect(MarcCleanup.bad_007?(record)).to eq true }
+      it { expect(MarcCleanup.bad_f007?(record)).to eq true }
     end
   end
 
-  describe 'fix_007' do
+  describe 'fix_f007' do
 
-    describe 'fix_map_007' do
+    describe 'fix_map_f007' do
       let(:leader) { '01104nea a2200289 i 4500' }
       let(:fields) { [ { '007' => 'ajzcanzn' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'aj canzn' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'aj canzn' }
     end
 
-    describe 'fix_electronic_007' do
+    describe 'fix_electronic_f007' do
       let(:leader) { '01104nma a2200289 i 4500' }
       let(:fields) { [ { '007' => 'caaaaa001aaaaa' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'ca aaa001aaaaa' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'ca aaa001aaaaa' }
     end
 
-    describe 'fix_globe_007' do
+    describe 'fix_globe_f007' do
       let(:leader) { '01104nea a2200289 i 4500' }
       let(:fields) { [ { '007' => 'da bau' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'da cau' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'da cau' }
     end
 
-    describe 'fix_tactile_007' do
+    describe 'fix_tactile_f007' do
       let(:leader) { '01104npa a2200289 i 4500' }
         let(:fields) { [ { '007' => 'fbza bnnnu' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'fb a bnnnu' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'fb a bnnnu' }
     end
 
-    describe 'fix_proj_007' do
+    describe 'fix_proj_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
       let(:fields) { [ { '007' => 'gcacebda ' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'gc cebda ' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'gc cebda ' }
     end
 
-    describe 'fix_microform_007' do
+    describe 'fix_microform_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
       let(:fields) { [ { '007' => 'hezbmb024aaaa' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'he bmb024uaaa' }
-    end    
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'he bmb024uaaa' }
+    end
 
-    describe 'fix_nonproj_007' do
+    describe 'fix_nonproj_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
       let(:fields) { [ { '007' => 'khacoo' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'kh coo' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'kh coo' }
     end
 
 
-    describe 'fix_motion_pic_007' do
+    describe 'fix_motion_pic_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
         let(:fields) { [ { '007' => 'mrabf  fnnartnnai198512' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'mr bf  fnnartnnai198512' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'mr bf  fnnartnnai198512' }
     end
 
-    describe 'fix_kit_007' do
+    describe 'fix_kit_f007' do
       let(:leader) { '01104nca a2200289 i 4500' }
       let(:fields) { [ { '007' => 'oz' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'ou' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'ou' }
     end
 
-    describe 'fix_notated_mus_007' do
+    describe 'fix_notated_mus_f007' do
       let(:leader) { '01104npa a2200289 i 4500' }
       let(:fields) { [ { '007' => 'qz' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'qu' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'qu' }
     end
 
-    describe 'fix_remote_007' do
+    describe 'fix_remote_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
         let(:fields) { [ { '007' => 'ruaaa0aaaaa' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'ru aa0aaaaa' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'ru aa0aaaaa' }
     end
 
-    describe 'fix_sound_rec_007' do
+    describe 'fix_sound_rec_f007' do
       let(:leader) { '01104npa a2200289 i 4500' }
 
       context 'when width is a' do
         let(:fields) { [ { '007' => 'sd ammaaaaahaa' } ] }
-        it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'sd ammamaaahaa' }
+        it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'sd ammamaaahaa' }
       end
 
       context 'when width is b' do
         let(:fields) { [ { '007' => 'sd ammabaaahaa' } ] }
-        it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'sd ammaoaaahaa' }
+        it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'sd ammaoaaahaa' }
       end
-        
+
       context 'when width is c' do
         let(:fields) { [ { '007' => 'sd ammacaaahaa' } ] }
-        it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'sd ammapaaahaa' }
+        it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'sd ammapaaahaa' }
       end
 
       context 'when mat_designation is f' do
         let(:fields) { [ { '007' => 'sf ammamaaahaa' } ] }
-        it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'si ammamaaahaa' }
+        it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'si ammamaaahaa' }
       end
 
       context 'when mat_designation is c' do
         let(:fields) { [ { '007' => 'sc ammamaaahaa' } ] }
-        it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'se ammamaaahaa' }
+        it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'se ammamaaahaa' }
       end
     end
 
-    describe 'fix_text_007' do
+    describe 'fix_text_f007' do
       let(:leader) { '01104naa a2200289 i 4500' }
         let(:fields) { [ { '007' => 'te' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'tu' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'tu' }
     end
 
-    describe 'fix_video_007' do
+    describe 'fix_video_f007' do
       let(:leader) { '01104nga a2200289 i 4500' }
       let(:fields) { [ { '007' => 'vcaaaaaok' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'vc aaaaok' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'vc aaaaok' }
     end
 
-    describe 'fix_unspec_007' do
+    describe 'fix_unspec_f007' do
       let(:leader) { '01104nab a2200289 i 4500' }
       let(:fields) { [ { '007' => 'za' } ] }
-      it { expect(MarcCleanup.fix_007(record)['007'].value).to eq 'zu' }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'zu' }
     end
   end
 end

--- a/spec/fixed_fields/008_spec.rb
+++ b/spec/fixed_fields/008_spec.rb
@@ -6,225 +6,225 @@ require 'marc_cleanup'
 RSpec.describe 'field 008 methods' do
   let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
 
-  describe 'multiple_no_008?' do
-    let(:leader) { '01104naa a2200289 i 4500' }   
-    
+  describe 'multiple_no_f008?' do
+    let(:leader) { '01104naa a2200289 i 4500' }
+
     context 'when there is more than one 008' do
-      let(:fields) do 
-        [ 
-          { '008' => '230414s9999||||xx |||||||||||||| ||eng||' }, 
-          { '008' => '230414s9999||||xx |||||||||||||| ||eng||' }   
-        ] 
+      let(:fields) do
+        [
+          { '008' => '230414s9999||||xx |||||||||||||| ||eng||' },
+          { '008' => '230414s9999||||xx |||||||||||||| ||eng||' }
+        ]
       end
-      it { expect(MarcCleanup.multiple_no_008?(record)).to eq true }
+      it { expect(MarcCleanup.multiple_no_f008?(record)).to eq true }
     end
-    
+
     context 'when there is less than one 008' do
       let(:fields) { [ { '001' => '99129117045606421' } ] }
-      it { expect(MarcCleanup.multiple_no_008?(record)).to eq true }
+      it { expect(MarcCleanup.multiple_no_f008?(record)).to eq true }
     end
 
     context 'when there is one 008' do
       let(:fields) { [ { '008' => '230414s9999||||xx |||||||||||||| ||eng||' } ] }
-      it { expect(MarcCleanup.multiple_no_008?(record)).to eq false }
+      it { expect(MarcCleanup.multiple_no_f008?(record)).to eq false }
     end
   end
-  
-  describe 'bad_008?' do
 
-    describe 'global 008 value check' do 
+  describe 'bad_f008?' do
+
+    describe 'global 008 value check' do
       let(:leader) { '01104naa a2200289 i 4500' }
 
       context 'when the global 008 values are invalid' do
         let(:fields) { [ { '008' => '230414s9999||||xx |||||||||||||| ||eng|x' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)'] }
-    
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)'] }
+
         context 'when the 008 is valid' do
           let(:fields) { [ { '008' => '230414s9999||||xx |||||||||||||| ||eng||' } ] }
-          it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+          it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
         end
       end
     end
 
     describe 'global and specific 008 check' do
       let(:leader) { '01104npa a2200289 i 4500' }
-    
+
       context 'when both the global and specific 008 values are invalid' do
         let(:fields) { [ { '008' => '230519s1996    njux   u      000 0 eng x' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)','Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)','Invalid value in the specific 008 (positions 18-34)'] }
       end
-    
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '230519s1996    nju     |           eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'book format 008' do
       let(:leader) { '01104naa a2200289 i 4500' }
-  
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '230414e199519  xx x||||||||||||| ||eng||' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:["Invalid value in the specific 008 (positions 18-34)"] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:["Invalid value in the specific 008 (positions 18-34)"] }
       end
- 
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '230414e199519  xx |||||||||||||| ||eng||' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'computer format 008' do
       let(:leader) { '01104nma a2200289 i 4500' }
-      
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '140108s2023    miu    fo  a       xeng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
       end
-      
+
       context 'when the 008 is valid' do
-        let(:fields) { [ { '008' => '140108s2023    miu    fo  a        eng d' } ] } 
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        let(:fields) { [ { '008' => '140108s2023    miu    fo  a        eng d' } ] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'map format 008' do
       let(:leader) { '01104nea a2200289 i 4500' }
-      
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '231127s2023    dcu|||||| |  || | ||eng z' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in global 008 (positions 0-17, 35-39)'] }
       end
-      
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '231127s2023    dcu|||||| |  || | ||eng c' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
 
     describe 'music format 008' do
-      let(:leader) { '01104nca a2200289 i 4500' }      
-      
+      let(:leader) { '01104nca a2200289 i 4500' }
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '230519s1996    njua   u      000 0 eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
       end
-      
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '230519s1996    nju|||||||||||||| | eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'continuing resource format 008' do
-      let(:leader) { '01104nab a2200289 i 4500' }  
-      
-      context 'when the 008 is invalid' do    
+      let(:leader) { '01104nab a2200289 i 4500' }
+
+      context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '230519s1996    njua   u aa   000 0 eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
       end
-      
+
       context 'when the 008 is valid' do
-        let(:fields) { [ { '008' => '230519s1996    nju|| |||aa  |0   ||eng d' } ] }        
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        let(:fields) { [ { '008' => '230519s1996    nju|| |||aa  |0   ||eng d' } ] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'visual format 008' do
-      let(:leader) { '01104nga a2200289 i 4500' }      
-      
+      let(:leader) { '01104nga a2200289 i 4500' }
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '230519s1996    njua   u      000 0 eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
       end
-      
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '230519s1996    nju||| |     ||   ||eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-    
+
     describe 'mixed materials format 008' do
       let(:leader) { '01104npa a2200289 i 4500' }
-    
+
       context 'when the 008 is invalid' do
         let(:fields) { [ { '008' => '230519s1996    njua   u      000 0 eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid value in the specific 008 (positions 18-34)'] }
       end
-    
+
       context 'when the 008 is valid' do
         let(:fields) { [ { '008' => '230519s1996    nju     |           eng d' } ] }
-        it { expect(MarcCleanup.bad_008?(record)).to eq valid:true, errors:[] }
+        it { expect(MarcCleanup.bad_f008?(record)).to eq valid:true, errors:[] }
       end
     end
-   
+
     describe 'bad 008 length' do
-      let(:leader) { '01104n a a2200289 i 4500' }      
+      let(:leader) { '01104n a a2200289 i 4500' }
       let(:fields) { [ { '008' => '230519s1996    njua         000 0 eng a' } ] }
-      it { expect(MarcCleanup.bad_008?(record)).to eq valid:false, errors:['Invalid 008 length'] }
+      it { expect(MarcCleanup.bad_f008?(record)).to eq valid:false, errors:['Invalid 008 length'] }
     end
   end
-  
-  describe 'fix_008' do
-    
-    describe 'fix_book_008' do
+
+  describe 'fix_f008' do
+
+    describe 'fix_book_f008' do
       let(:leader) { '01104naa a2200289 i 4500' }
-      
+
       context 'when contents char is h' do
         let(:fields) { [ { '008' => '230519s1996    njuax     h   000 0 eng a' } ] }
-        it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua     f    000 0 eng  ' }
+        it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua     f    000 0 eng  ' }
       end
 
       context 'when contents char is 3' do
         let(:fields) { [ { '008' => '230519s1996    njuax     3   000 0 eng a' } ] }
-        it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua     k    000 0 eng  ' }
-      end      
+        it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua     k    000 0 eng  ' }
+      end
 
       context 'when contents char is x' do
         let(:fields) { [ { '008' => '230519s1996    njuax     x   000 0 eng a' } ] }
-        it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua     t    000 0 eng  ' }
+        it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua     t    000 0 eng  ' }
       end
 
       context 'when contents char is 4' do
         let(:fields) { [ { '008' => '230519s1996    njuax     4   000 0 eng a' } ] }
-        it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua     q    000 0 eng  ' }
-      end      
+        it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua     q    000 0 eng  ' }
+      end
     end
-    
-    describe 'fix_comp_008' do
-      let(:leader) { '01104nma a2200289 i 4500' }      
+
+    describe 'fix_comp_f008' do
+      let(:leader) { '01104nma a2200289 i 4500' }
       let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng o' } ] }
-      it { expect(MarcCleanup.fix_008(record)['008'].value).to eq '230519s1996    nju                 eng d' }
+      it { expect(MarcCleanup.fix_f008(record)['008'].value).to eq '230519s1996    nju                 eng d' }
+    end
+
+    describe 'fix_map_f008' do
+      let(:leader) { '01104nea a2200289 i 4500' }
+      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
+      it {expect(MarcCleanup.fix_f008(record)['008'].value).to eq '230519s1996    njua          0 0   eng d' }
+    end
+
+    describe 'fix_music_f008' do
+      let(:leader) { '01104nca a2200289 i 4500' }
+      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
+      it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua              0 eng d' }
+    end
+
+    describe 'fix_continuing_resource_f008' do
+      let(:leader) { '01104nab a2200289 i 4500' }
+      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
+      it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua          0   0 eng d' }
+    end
+
+    describe 'fix_visual_f008' do
+      let(:leader) { '01104nga a2200289 i 4500' }
+      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
+      it { expect(fix_f008(record)['008'].value).to eq '230519s1996    njua          0   0neng d' }
     end
     
-    describe 'fix_map_008' do
-      let(:leader) { '01104nea a2200289 i 4500' }      
-      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
-      it {expect(MarcCleanup.fix_008(record)['008'].value).to eq '230519s1996    njua          0 0   eng d' }
-    end
-    
-    describe 'fix_music_008' do
-      let(:leader) { '01104nca a2200289 i 4500' }      
-      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
-      it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua              0 eng d' }
-    end  
-    
-    describe 'fix_continuing_resource_008' do
-      let(:leader) { '01104nab a2200289 i 4500' }      
-      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
-      it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua          0   0 eng d' }
-    end
-    
-    describe 'fix_visual_008' do
-      let(:leader) { '01104nga a2200289 i 4500' }      
-      let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
-      it { expect(fix_008(record)['008'].value).to eq '230519s1996    njua          0   0neng d' }   
-    end
-    
-    describe 'fix_mix_mat_008' do
+    describe 'fix_mix_mat_f008' do
       let(:leader) { '01104npa a2200289 i 4500' }
       let(:fields) { [ { '008' => '230519s1996    njua          000 0 eng d' } ] }
-      it { expect(fix_008(record)['008'].value).to eq '230519s1996    nju                 eng d'}
-    end   
+      it { expect(fix_f008(record)['008'].value).to eq '230519s1996    nju                 eng d'}
+    end
   end
-end  
+end


### PR DESCRIPTION
Normalized method names to follow normalcase; refactored methods to allow `frozen_string_literal` to be applied.

I then allowed rubocop to autofix stylistic issues.