### PR TITLE
change method name to f008_errors; refactor map and electronic 007 fixes

### DIFF
--- a/spec/fixed_fields/007_spec.rb
+++ b/spec/fixed_fields/007_spec.rb
@@ -229,8 +229,8 @@ RSpec.describe 'fields 007 methods' do
 
     describe 'fix_electronic_f007' do
       let(:leader) { '01104nma a2200289 i 4500' }
-      let(:fields) { [ { '007' => 'caaaaa001aaaaa' } ] }
-      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'ca aaa001aaaaa' }
+      let(:fields) { [ { '007' => 'caaaaa001xaaaa' } ] }
+      it { expect(MarcCleanup.fix_f007(record)['007'].value).to eq 'ca aaa001uaaaa' }
     end
 
     describe 'fix_globe_f007' do

--- a/spec/fixed_fields/008_spec.rb
+++ b/spec/fixed_fields/008_spec.rb
@@ -32,20 +32,20 @@ RSpec.describe 'field 008 methods' do
     end
   end
 
-  describe 'bad_f008?' do
+  describe 'f008_errors' do
     describe 'global 008 value check' do
       let(:leader) { '01104naa a2200289 i 4500' }
 
       context 'when the global 008 values are invalid' do
         let(:fields) { [{ '008' => '230414s9999||||xx |||||||||||||| ||eng|x' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in global 008 (positions 0-17, 35-39)']
         }
 
         context 'when the 008 is valid' do
           let(:fields) { [{ '008' => '230414s9999||||xx |||||||||||||| ||eng||' }] }
-          it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+          it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
         end
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe 'field 008 methods' do
       context 'when the global 008 values are valid' do
         let(:fields) { [{ '008' => '230414s9999||||xx |||||||||||||| ||eng||' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: [
                                                         'Invalid value in the specific 008 (positions 18-34)'
                                                       ]
@@ -70,7 +70,7 @@ RSpec.describe 'field 008 methods' do
       context 'when both the global and specific 008 values are invalid' do
         let(:fields) { [{ '008' => '230519s1996    njux   u      000 0 eng x' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: [
                                                         'Invalid value in global 008 (positions 0-17, 35-39)',
                                                         'Invalid value in the specific 008 (positions 18-34)'
@@ -80,7 +80,7 @@ RSpec.describe 'field 008 methods' do
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230519s1996    nju     |           eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -90,14 +90,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '230414e199519  xx x||||||||||||| ||eng||' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230414e199519  xx |||||||||||||| ||eng||' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -107,14 +107,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '140108s2023    miu    fo  a       xeng d' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '140108s2023    miu    fo  a        eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -124,14 +124,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '231127s2023    dcu|||||| |  || | ||eng z' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in global 008 (positions 0-17, 35-39)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '231127s2023    dcu|||||| |  || | ||eng c' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -141,14 +141,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '230519s1996    njua   u      000 0 eng d' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230519s1996    nju|||||||||||||| | eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -158,14 +158,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '230519s1996    njua   u aa   000 0 eng d' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230519s1996    nju|| |||aa  |0   ||eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -175,14 +175,14 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '230519s1996    njua   u      000 0 eng d' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230519s1996    nju||| |     ||   ||eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
@@ -192,21 +192,21 @@ RSpec.describe 'field 008 methods' do
       context 'when the 008 is invalid' do
         let(:fields) { [{ '008' => '230519s1996    njua   u      000 0 eng d' }] }
         it {
-          expect(MarcCleanup.bad_f008?(record)).to eq valid: false,
+          expect(MarcCleanup.f008_errors(record)).to eq valid: false,
                                                       errors: ['Invalid value in the specific 008 (positions 18-34)']
         }
       end
 
       context 'when the 008 is valid' do
         let(:fields) { [{ '008' => '230519s1996    nju     |           eng d' }] }
-        it { expect(MarcCleanup.bad_f008?(record)).to eq valid: true, errors: [] }
+        it { expect(MarcCleanup.f008_errors(record)).to eq valid: true, errors: [] }
       end
     end
 
     describe 'bad 008 length' do
       let(:leader) { '01104n a a2200289 i 4500' }
       let(:fields) { [{ '008' => '230519s1996    njua         000 0 eng a' }] }
-      it { expect(MarcCleanup.bad_f008?(record)).to eq valid: false, errors: ['Invalid 008 length'] }
+      it { expect(MarcCleanup.f008_errors(record)).to eq valid: false, errors: ['Invalid 008 length'] }
     end
   end
 


### PR DESCRIPTION
Using hashes for storing method names and regexes is going a long way towards making logic easier to follow. Before proceeding with refactoring all the 007 and 008 fixes, I'm hoping to get a validation of the overall approach.

The eventual goal is to create a class (or classes) based on validate_marc to find all errors contained in a MARC record, and classes to fix all errors that can be fixed. My thinking is that if all lines of code are tested, and all code follows the rubocop style guide, moving methods into classes (like a `validate_fixed_fields` class or `correct_fixed_fields`) will be much simpler.